### PR TITLE
fix: duplicate uuid

### DIFF
--- a/suzaku/aws_cloudtrail_attempt_to_create_api_key.yml
+++ b/suzaku/aws_cloudtrail_attempt_to_create_api_key.yml
@@ -1,5 +1,5 @@
 title: Attempt To Create API Key
-id: 3b07ff19-d7b8-44ba-afa5-d2d6fb8cb22f
+id: 1497f3a3-7898-484e-b1e8-22fe99efd8a4
 status: test
 description: |
     An attacker may have attemped to create an API key for persistence but it failed.
@@ -11,7 +11,7 @@ references:
     - https://traildiscover.cloud/#AppSync-CreateApiKey
 author: Zach Mathis (@yamatosecurity)
 date: 2025-04-23
-modified: 2025-04-23
+modified: 2025-05-31
 tags:
     - attack.defense-evasion
     - attack.persistence

--- a/suzaku/aws_cloudtrail_get_caller_identity.yml
+++ b/suzaku/aws_cloudtrail_get_caller_identity.yml
@@ -1,5 +1,5 @@
 title: Get Caller Identity
-id: 3b07ff19-d7b8-44ba-afa5-d2d6fb8cb22f
+id: 0e854216-b78f-4e05-9d62-1314cf16bb40
 status: test
 description: |
     The "whoami" for AWS. Attackers will often use this to determine the identity of the current user or role. This is a common first step in AWS reconnaissance.
@@ -9,7 +9,7 @@ references:
     - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
 author: Zach Mathis (@yamatosecurity)
 date: 2025-04-24
-modified: 2025-04-24
+modified: 2025-05-31
 tags:
     - attack.discovery
 logsource:


### PR DESCRIPTION
I noticed the UUID of the following rule was duplicated, so I fixed it!

- https://github.com/Yamato-Security/suzaku-rules/blob/46c21eca20dcafb0640a874caa07a81fb42ccaa4/suzaku/aws_cloudtrail_api_key_created.yml#L2
- https://github.com/Yamato-Security/suzaku-rules/blob/46c21eca20dcafb0640a874caa07a81fb42ccaa4/suzaku/aws_cloudtrail_attempt_to_create_api_key.yml#L2
- https://github.com/Yamato-Security/suzaku-rules/blob/46c21eca20dcafb0640a874caa07a81fb42ccaa4/suzaku/aws_cloudtrail_get_caller_identity.yml#L2

