### PR TITLE
fix: duplicate uuid and add check GitHub Actions

### DIFF
--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Check for duplicate id in yml files
         run: |
+          cd suzaku
           count=$(grep -h '^id:' **/*.yml | sort | uniq -c | awk '$1 > 1 {print $0}' | wc -l)
           if [ "$count" -ne 0 ]; then
             echo "Duplicate uuid found in yml files"

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -1,0 +1,24 @@
+name: Check duplicate UUID in sigma rules
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  checkDuplicateUUID:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: Yamato-Security/suzaku
+          path: suzaku
+
+      - name: Check for duplicate id in yml files
+        run: |
+          count=$(grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | sort -nr | grep -v "1 id" | wc -l)
+          if [ "$count" -ne 0 ]; then
+            echo "Duplicate uuid found in yml files"
+            exit 1
+          fi

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -18,7 +18,8 @@ jobs:
       - name: Check for duplicate id in yml files
         run: |
           cd suzaku
-          count=$(grep -h '^id:' **/*.yml | sort | uniq -c | awk '$1 > 1 {print $0}' | wc -l)
+          shopt -s globstar
+          count=$(grep -h '^id:' **/*.yml 2>/dev/null | sort | uniq -c | awk '$1 > 1 {print $0}' | wc -l)
           if [ "$count" -ne 0 ]; then
             echo "Duplicate uuid found in yml files"
             exit 1

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Check for duplicate id in yml files
         run: |
-          count=$(grep -h '^id:' **/*.yml | sort | uniq -c | sort -nr | grep -v "1 id" | wc -l)
+          count=$(grep -h '^id:' **/*.yml | sort | uniq -c | awk '$1 > 1 {print $0}' | wc -l)
           if [ "$count" -ne 0 ]; then
             echo "Duplicate uuid found in yml files"
             exit 1

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Check for duplicate id in yml files
         run: |
-          count=$(grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | sort -nr | grep -v "1 id" | wc -l)
+          count=$(grep -h '^id:' **/*.yml | sort | uniq -c | sort -nr | grep -v "1 id" | wc -l)
           if [ "$count" -ne 0 ]; then
             echo "Duplicate uuid found in yml files"
             exit 1

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Check for duplicate id in yml files
         run: |
-          count=$(grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | sort -nr | grep -v "1 id" | wc -l)
+          count=$(grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | awk '$1 > 1 {print $0}' | wc -l)
           if [ "$count" -ne 0 ]; then
             echo "Duplicate uuid found in yml files"
             exit 1

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Check for duplicate id in yml files
         run: |
-          count=$(grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | awk '$1 > 1 {print $0}' | wc -l)
+          count=$(grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | sort -nr | grep -v "1 id" | wc -l)
           if [ "$count" -ne 0 ]; then
             echo "Duplicate uuid found in yml files"
             exit 1

--- a/suzaku/aws_cloudtrail_log_settings_modified.yml
+++ b/suzaku/aws_cloudtrail_log_settings_modified.yml
@@ -1,5 +1,5 @@
 title: CloudTrail Log Settings Modified
-id: 0f11648b-4759-4491-9ff0-e61a28010bfd
+id: 295b96b0-3345-4856-bd2f-2ca61ec89add
 status: test
 description: |
     An attacker may have attempted to modify CloudTrail log settings for anti-forensics but it was denied due to a lack of permissions.


### PR DESCRIPTION
Sorry, I noticed that there were other duplicated UUIDs as well, so I’ve fixed them.
```
grep -h '^id:' suzaku/**/*.yml | sort | uniq -c | sort -nr                 
   2 id: 0f11648b-4759-4491-9ff0-e61a28010bfd
   1 id: fa5c25ee-9c78-4af4-916f-52a81d1d16e6
   1 id: f96305fe-e0ab-4d0f-acb3-bc8ee4f0e098
   1 id: dd9381d0-bde9-464d-ba68-dba31fe177e1
   1 id: dbd3daf6-4e63-4d58-ab76-5f91a18e42c5
   1 id: da90c11e-e3d4-411e-aaf7-06d02e0c5c23
   1 id: c85a99f2-bdfa-4d4a-8645-52628b2e4106
   1 id: c7c08505-e4ed-49e0-bb61-292f445060d5
   1 id: b6f02c52-1158-4d31-98a8-a4751718f3db
   1 id: b1a88df9-bf9f-48f4-a1c8-1d443923b951
   1 id: a74c0244-43fa-47ea-90bf-802500dd3140
   1 id: 6125226d-0eb4-4dc8-8cb6-ac5ad01973ab
   1 id: 535c3745-3883-4cc8-a635-1a56cc3d6384
   1 id: 4ae38c23-b180-4120-87bf-7bf5cb18dd5b
   1 id: 41b73340-8b0d-438f-9d35-ae0b4a21f136
   1 id: 3b07ff19-d7b8-44ba-afa5-d2d6fb8cb22f
   1 id: 372d79d1-73c5-48db-aa98-18b1a03fc9fc
   1 id: 21a06b91-4860-4d2c-96fb-5c5c6374e3b2
   1 id: 1497f3a3-7898-484e-b1e8-22fe99efd8a4
   1 id: 0e854216-b78f-4e05-9d62-1314cf16bb40
```
https://github.com/Yamato-Security/suzaku-rules/blob/87e872ae0cbda92544232dc17ac5dc69d3d695dc/suzaku/aws_cloudtrail_log_settings_modified.yml#L2
https://github.com/Yamato-Security/suzaku-rules/blob/87e872ae0cbda92544232dc17ac5dc69d3d695dc/suzaku/aws_cloudtrail_attempt_to_modify_log_settings.yml#L2

Additionally, I’ve added a GitHub Actions workflow to check for duplicate UUIDs!