### PR TITLE
chore: update action versions and adjust permissions in workflow files

### DIFF
--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -9,7 +9,7 @@ jobs:
   checkDuplicateUUID:
     runs-on: ubuntu-latest
     permissions:
-        contents: read
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-duplicate-uuid.yaml
+++ b/.github/workflows/check-duplicate-uuid.yaml
@@ -8,9 +8,11 @@ on:
 jobs:
   checkDuplicateUUID:
     runs-on: ubuntu-latest
+    permissions:
+        contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/suzaku
           path: suzaku

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -13,16 +13,19 @@ on:
 jobs:
   updateSigmaRule:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: clone sigma
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: SigmaHQ/sigma
           path: sigma
           token: ${{ secrets.GITHUB_TOKEN }} ## This is necessary for executing on a local machine by act(Local GitHub Action Runner). We have to specify the github token explicitly.
 
       - name: clone suzaku rule repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: suzaku-rules
 
@@ -82,7 +85,7 @@ jobs:
       - name: Create Pull Request
         if: env.change_exist == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
         with:
           path: suzaku-rules
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +99,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created' # This only runs if there were sigma rules updates and a new PR was created.
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -104,7 +107,7 @@ jobs:
 
       - name: upload change log
         if: env.change_exist == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: changed_rule_log
           path: ${{ github.workspace }}/changed_rule.logs


### PR DESCRIPTION
## What Changed
I have updated third-party action references to use full-length commit SHA, following the best practices.
- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

I’d appreciate it if you could check it when you have time🙏