### PR TITLE
feat: add 9 CloudTrail detection rules derived from honeypot observations

### DIFF
--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
@@ -1,4 +1,4 @@
-title: Attempt To Attach Policy
+title: IAM Policy Attachment Attempt
 id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
 status: test
 description: |

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
@@ -1,0 +1,39 @@
+title: Attempt To Attach Admin Policy
+id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
+status: test
+description: |
+    Detects a failed attempt to attach an administrative IAM policy
+    (AdministratorAccess, PowerUserAccess, or IAMFullAccess).
+    Even though the attempt was denied, it indicates the attacker has valid
+    credentials and is attempting privilege escalation. This is commonly
+    observed when attackers use stolen credentials that lack IAM write
+    permissions, such as canary tokens or limited-scope service accounts.
+references:
+    - https://attack.mitre.org/techniques/T1098/003/
+    - https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html
+    - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+author: i-wind (@iwind)
+date: 2026-05-28
+modified: 2026-05-28
+tags:
+    - attack.privilege_escalation
+    - attack.t1098.003
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName:
+            - AttachUserPolicy
+            - AttachGroupPolicy
+            - AttachRolePolicy
+        errorCode: AccessDenied
+    selection_admin:
+        requestParameters.policyArn|contains:
+            - AdministratorAccess
+            - PowerUserAccess
+            - IAMFullAccess
+    condition: selection and selection_admin
+falsepositives:
+level: high

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
@@ -12,7 +12,7 @@ references:
     - https://attack.mitre.org/techniques/T1098/003/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html
     - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-28
 modified: 2026-05-28
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_attach_admin_policy.yml
@@ -1,22 +1,23 @@
-title: Attempt To Attach Admin Policy
+title: Attempt To Attach Policy
 id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
 status: test
 description: |
-    Detects a failed attempt to attach an administrative IAM policy
-    (AdministratorAccess, PowerUserAccess, or IAMFullAccess).
+    Detects a failed attempt to attach an IAM policy to a user, group, or role.
     Even though the attempt was denied, it indicates the attacker has valid
     credentials and is attempting privilege escalation. This is commonly
     observed when attackers use stolen credentials that lack IAM write
-    permissions, such as canary tokens or limited-scope service accounts.
+    permissions.
+    Note: AccessDenied events may have empty requestParameters, so this rule
+    does not filter by policy name to avoid missing detections.
 references:
     - https://attack.mitre.org/techniques/T1098/003/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html
     - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-28
-modified: 2026-05-28
+modified: 2026-05-29
 tags:
-    - attack.privilege_escalation
+    - attack.privilege-escalation
     - attack.t1098.003
 logsource:
     product: aws
@@ -29,11 +30,6 @@ detection:
             - AttachGroupPolicy
             - AttachRolePolicy
         errorCode: AccessDenied
-    selection_admin:
-        requestParameters.policyArn|contains:
-            - AdministratorAccess
-            - PowerUserAccess
-            - IAMFullAccess
-    condition: selection and selection_admin
+    condition: selection
 falsepositives:
-level: high
+level: medium

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
@@ -10,7 +10,7 @@ description: |
 references:
     - https://attack.mitre.org/techniques/T1098/001/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-28
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
@@ -5,14 +5,12 @@ description: |
     Detects a failed attempt to create an IAM access key (AccessDenied).
     Even though the attempt failed, it indicates the attacker has valid
     credentials and is attempting persistence via access key creation.
-    Commonly observed when stolen credentials have a deny-all or
-    limited-permission policy (e.g., canary/honeypot tokens).
 references:
     - https://attack.mitre.org/techniques/T1098/001/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-28
+modified: 2026-05-29
 tags:
     - attack.persistence
     - attack.t1098.001

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
@@ -1,4 +1,4 @@
-title: Attempt To Create IAM Access Key
+title: IAM Access Key Creation Attempt
 id: 2c4d6e8f-0a1b-3c5d-7e9f-1a2b3c4d5e70
 status: test
 description: |

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_access_key.yml
@@ -1,0 +1,29 @@
+title: Attempt To Create IAM Access Key
+id: 2c4d6e8f-0a1b-3c5d-7e9f-1a2b3c4d5e70
+status: test
+description: |
+    Detects a failed attempt to create an IAM access key (AccessDenied).
+    Even though the attempt failed, it indicates the attacker has valid
+    credentials and is attempting persistence via access key creation.
+    Commonly observed when stolen credentials have a deny-all or
+    limited-permission policy (e.g., canary/honeypot tokens).
+references:
+    - https://attack.mitre.org/techniques/T1098/001/
+    - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-28
+tags:
+    - attack.persistence
+    - attack.t1098.001
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName: CreateAccessKey
+        errorCode: AccessDenied
+    condition: selection
+falsepositives:
+level: medium

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
@@ -1,4 +1,4 @@
-title: Attempt To Create IAM User
+title: IAM User Creation Attempt
 id: 8f3a7b2c-1d4e-5f6a-9b0c-2e3d4f5a6b7d
 status: test
 description: |

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
@@ -6,14 +6,14 @@ description: |
     Even though the attempt failed, it indicates the attacker has valid
     credentials and is attempting persistence via IAM user creation.
 references:
-    - https://attack.mitre.org/techniques/T1136/001/
+    - https://attack.mitre.org/techniques/T1136/003/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.persistence
-    - attack.t1136.001
+    - attack.t1136.003
 logsource:
     product: aws
     service: cloudtrail

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
@@ -8,7 +8,7 @@ description: |
 references:
     - https://attack.mitre.org/techniques/T1136/001/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_attempt_to_create_iam_user.yml
@@ -1,0 +1,27 @@
+title: Attempt To Create IAM User
+id: 8f3a7b2c-1d4e-5f6a-9b0c-2e3d4f5a6b7d
+status: test
+description: |
+    Detects a failed attempt to create an IAM user (AccessDenied).
+    Even though the attempt failed, it indicates the attacker has valid
+    credentials and is attempting persistence via IAM user creation.
+references:
+    - https://attack.mitre.org/techniques/T1136/001/
+    - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.persistence
+    - attack.t1136.001
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName: CreateUser
+        errorCode: AccessDenied
+    condition: selection
+falsepositives:
+level: medium

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_access_key_created.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_access_key_created.yml
@@ -11,7 +11,7 @@ references:
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.persistence
     - attack.t1098.001
@@ -23,7 +23,7 @@ detection:
         eventSource: iam.amazonaws.com
         eventName: CreateAccessKey
     filter:
-        errorCode: AccessDenied
+        errorCode|exists: true
     condition: selection and not filter
 falsepositives:
     - Legitimate key rotation by administrators or automation

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_access_key_created.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_access_key_created.yml
@@ -9,7 +9,7 @@ description: |
 references:
     - https://attack.mitre.org/techniques/T1098/001/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_access_key_created.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_access_key_created.yml
@@ -1,0 +1,30 @@
+title: IAM Access Key Created
+id: 2c4d6e8f-0a1b-3c5d-7e9f-1a2b3c4d5e6f
+status: test
+description: |
+    Detects when an IAM access key is created via CreateAccessKey.
+    Attackers create access keys for persistence after compromising an account,
+    often targeting an existing user or a newly created backdoor user.
+    Note: This is different from CreateApiKey (AppSync/API Gateway).
+references:
+    - https://attack.mitre.org/techniques/T1098/001/
+    - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.persistence
+    - attack.t1098.001
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName: CreateAccessKey
+    filter:
+        errorCode: AccessDenied
+    condition: selection and not filter
+falsepositives:
+    - Legitimate key rotation by administrators or automation
+level: medium

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_admin_policy_attached.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_admin_policy_attached.yml
@@ -11,7 +11,7 @@ references:
     - https://attack.mitre.org/techniques/T1098/003/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html
     - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_admin_policy_attached.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_admin_policy_attached.yml
@@ -13,9 +13,9 @@ references:
     - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
-    - attack.privilege_escalation
+    - attack.privilege-escalation
     - attack.persistence
     - attack.t1098.003
 logsource:
@@ -34,7 +34,7 @@ detection:
             - PowerUserAccess
             - IAMFullAccess
     filter:
-        errorCode: AccessDenied
+        errorCode|exists: true
     condition: selection and selection_admin and not filter
 falsepositives:
     - Legitimate IAM administrators granting access during onboarding

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_admin_policy_attached.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_admin_policy_attached.yml
@@ -1,0 +1,42 @@
+title: IAM Admin Policy Attached
+id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
+status: test
+description: |
+    Detects when an administrative IAM policy (AdministratorAccess,
+    PowerUserAccess, or IAMFullAccess) is attached to a user, group, or role.
+    This is a privilege escalation technique where an attacker elevates
+    permissions of a compromised or newly created principal to gain full
+    control of the AWS account.
+references:
+    - https://attack.mitre.org/techniques/T1098/003/
+    - https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html
+    - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.privilege_escalation
+    - attack.persistence
+    - attack.t1098.003
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName:
+            - AttachUserPolicy
+            - AttachGroupPolicy
+            - AttachRolePolicy
+    selection_admin:
+        requestParameters.policyArn|contains:
+            - AdministratorAccess
+            - PowerUserAccess
+            - IAMFullAccess
+    filter:
+        errorCode: AccessDenied
+    condition: selection and selection_admin and not filter
+falsepositives:
+    - Legitimate IAM administrators granting access during onboarding
+    - Infrastructure-as-code deployments (Terraform, CloudFormation)
+level: critical

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
@@ -6,17 +6,17 @@ description: |
     CreateAccessKey from the same source IP within a short time window.
     This two-step sequence is a classic post-compromise persistence technique
     to ensure continued access even after the originally compromised credentials
-    are rotated.
+    are rotated. Only fires on successful operations (no errorCode).
 references:
-    - https://attack.mitre.org/techniques/T1136/001/
+    - https://attack.mitre.org/techniques/T1136/003/
     - https://attack.mitre.org/techniques/T1098/001/
     - https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.persistence
-    - attack.t1136.001
+    - attack.t1136.003
     - attack.t1098.001
 logsource:
     product: aws
@@ -28,6 +28,7 @@ correlation:
         - IAM CreateAccessKey
     group-by:
         - sourceIPAddress
+        - userIdentity.accessKeyId
     timespan: 10m
     generate: false
 level: critical
@@ -35,11 +36,11 @@ level: critical
 title: IAM CreateUser
 id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2c
 status: test
-description: Base rule for IAM CreateUser correlation.
+description: Base rule for successful IAM CreateUser correlation.
 references:
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.persistence
 logsource:
@@ -49,17 +50,19 @@ detection:
     selection:
         eventSource: iam.amazonaws.com
         eventName: CreateUser
-    condition: selection
+    filter:
+        errorCode|exists: true
+    condition: selection and not filter
 level: informational
 ---
 title: IAM CreateAccessKey
 id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2d
 status: test
-description: Base rule for IAM CreateAccessKey correlation.
+description: Base rule for successful IAM CreateAccessKey correlation.
 references:
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.persistence
 logsource:
@@ -69,5 +72,7 @@ detection:
     selection:
         eventSource: iam.amazonaws.com
         eventName: CreateAccessKey
-    condition: selection
+    filter:
+        errorCode|exists: true
+    condition: selection and not filter
 level: informational

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
@@ -11,7 +11,7 @@ references:
     - https://attack.mitre.org/techniques/T1136/001/
     - https://attack.mitre.org/techniques/T1098/001/
     - https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:
@@ -37,7 +37,7 @@ id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2c
 status: test
 description: Base rule for IAM CreateUser correlation.
 references:
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:
@@ -57,7 +57,7 @@ id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2d
 status: test
 description: Base rule for IAM CreateAccessKey correlation.
 references:
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
@@ -1,4 +1,4 @@
-title: IAM Persistence Chain - CreateUser Followed by CreateAccessKey
+title: IAM Persis Chain via User and Access Key Creation
 id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2b
 status: test
 description: |

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_persistence_chain.yml
@@ -1,0 +1,73 @@
+title: IAM Persistence Chain - CreateUser Followed by CreateAccessKey
+id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2b
+status: test
+description: |
+    Detects the full IAM persistence attack chain: CreateUser followed by
+    CreateAccessKey from the same source IP within a short time window.
+    This two-step sequence is a classic post-compromise persistence technique
+    to ensure continued access even after the originally compromised credentials
+    are rotated.
+references:
+    - https://attack.mitre.org/techniques/T1136/001/
+    - https://attack.mitre.org/techniques/T1098/001/
+    - https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.persistence
+    - attack.t1136.001
+    - attack.t1098.001
+logsource:
+    product: aws
+    service: cloudtrail
+correlation:
+    type: temporal_ordered
+    rules:
+        - IAM CreateUser
+        - IAM CreateAccessKey
+    group-by:
+        - sourceIPAddress
+    timespan: 10m
+    generate: false
+level: critical
+---
+title: IAM CreateUser
+id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2c
+status: test
+description: Base rule for IAM CreateUser correlation.
+references:
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.persistence
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName: CreateUser
+    condition: selection
+level: informational
+---
+title: IAM CreateAccessKey
+id: 8e0f2a4b-6c7d-9e1f-3a5b-7c8d9e0f1a2d
+status: test
+description: Base rule for IAM CreateAccessKey correlation.
+references:
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.persistence
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName: CreateAccessKey
+    condition: selection
+level: informational

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_user_created.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_user_created.yml
@@ -1,0 +1,32 @@
+title: IAM User Created
+id: 8f3a7b2c-1d4e-5f6a-9b0c-2e3d4f5a6b7c
+status: test
+description: |
+    Detects when an IAM user creates a new IAM user via CreateUser.
+    This is a common persistence technique where an attacker with compromised
+    credentials creates a backdoor IAM user for continued access even after
+    the originally compromised credentials are rotated.
+references:
+    - https://attack.mitre.org/techniques/T1136/001/
+    - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html
+    - https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.persistence
+    - attack.t1136.001
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: iam.amazonaws.com
+        eventName: CreateUser
+    filter:
+        errorCode: AccessDenied
+    condition: selection and not filter
+falsepositives:
+    - Legitimate IAM administrators creating new users
+    - Automated provisioning systems (Terraform, CloudFormation, SCIM)
+level: high

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_user_created.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_user_created.yml
@@ -7,15 +7,15 @@ description: |
     credentials creates a backdoor IAM user for continued access even after
     the originally compromised credentials are rotated.
 references:
-    - https://attack.mitre.org/techniques/T1136/001/
+    - https://attack.mitre.org/techniques/T1136/003/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html
     - https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.persistence
-    - attack.t1136.001
+    - attack.t1136.003
 logsource:
     product: aws
     service: cloudtrail
@@ -24,7 +24,7 @@ detection:
         eventSource: iam.amazonaws.com
         eventName: CreateUser
     filter:
-        errorCode: AccessDenied
+        errorCode|exists: true
     condition: selection and not filter
 falsepositives:
     - Legitimate IAM administrators creating new users

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_iam_user_created.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_iam_user_created.yml
@@ -10,7 +10,7 @@ references:
     - https://attack.mitre.org/techniques/T1136/001/
     - https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html
     - https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
@@ -1,0 +1,52 @@
+title: Many AccessDenied Errors from Single IP
+id: 4a6b8c0d-2e3f-5a7b-9c1d-3e4f5a6b7c8d
+status: test
+description: |
+    Detects multiple AccessDenied errors from the same source IP within a short time window.
+    This pattern indicates an attacker probing AWS APIs with stolen credentials that have
+    restricted permissions (e.g., a deny-all policy on a honeypot canary user, or a
+    compromised user with limited permissions).
+    Attackers who obtain credentials via SSRF, leaked .env files, or code repositories
+    typically enumerate dozens of AWS APIs to discover what they can access.
+references:
+    - https://attack.mitre.org/techniques/T1580/
+    - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.discovery
+    - attack.t1580
+logsource:
+    product: aws
+    service: cloudtrail
+correlation:
+    type: event_count
+    rules:
+        - AccessDenied Error
+    group-by:
+        - sourceIPAddress
+    timespan: 10m
+    condition:
+        gte: 10
+    generate: false
+level: high
+---
+title: AccessDenied Error
+id: 4a6b8c0d-2e3f-5a7b-9c1d-3e4f5a6b7c8e
+status: test
+description: Base rule for AccessDenied correlation.
+references:
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.discovery
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        errorCode: AccessDenied
+    condition: selection
+level: informational

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
@@ -1,19 +1,19 @@
-title: Many AccessDenied Errors from Single IP
+title: Many AccessDenied Errors from Single Source
 id: 4a6b8c0d-2e3f-5a7b-9c1d-3e4f5a6b7c8d
 status: test
 description: |
-    Detects multiple AccessDenied errors from the same source IP within a short time window.
-    This pattern indicates an attacker probing AWS APIs with stolen credentials that have
-    restricted permissions (e.g., a deny-all policy on a honeypot canary user, or a
-    compromised user with limited permissions).
-    Attackers who obtain credentials via SSRF, leaked .env files, or code repositories
-    typically enumerate dozens of AWS APIs to discover what they can access.
+    Detects multiple AccessDenied errors from the same source IP and access key
+    within a short time window. This pattern indicates an attacker probing AWS
+    APIs with stolen credentials that have restricted permissions.
+    Attackers who obtain credentials via SSRF, leaked .env files, or code
+    repositories typically enumerate dozens of AWS APIs to discover what they
+    can access.
 references:
     - https://attack.mitre.org/techniques/T1580/
     - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.discovery
     - attack.t1580
@@ -26,6 +26,7 @@ correlation:
         - AccessDenied Error
     group-by:
         - sourceIPAddress
+        - userIdentity.accessKeyId
     timespan: 10m
     condition:
         gte: 10
@@ -39,7 +40,7 @@ description: Base rule for AccessDenied correlation.
 references:
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.discovery
 logsource:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
@@ -2,9 +2,10 @@ title: Many AccessDenied Errors from Single Source
 id: 4a6b8c0d-2e3f-5a7b-9c1d-3e4f5a6b7c8d
 status: test
 description: |
-    Detects multiple AccessDenied errors from the same source IP and access key
-    within a short time window. This pattern indicates an attacker probing AWS
-    APIs with stolen credentials that have restricted permissions.
+    Detects multiple authorization failure errors from the same source IP and
+    access key within a short time window. This pattern indicates an attacker
+    probing AWS APIs with stolen credentials that have restricted permissions.
+    Covers both IAM-level AccessDenied and EC2-style Client.UnauthorizedOperation.
     Attackers who obtain credentials via SSRF, leaked .env files, or code
     repositories typically enumerate dozens of AWS APIs to discover what they
     can access.
@@ -48,6 +49,8 @@ logsource:
     service: cloudtrail
 detection:
     selection:
-        errorCode: AccessDenied
+        errorCode:
+            - AccessDenied
+            - Client.UnauthorizedOperation
     condition: selection
 level: informational

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_many_access_denied.yml
@@ -11,7 +11,7 @@ description: |
 references:
     - https://attack.mitre.org/techniques/T1580/
     - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:
@@ -37,7 +37,7 @@ id: 4a6b8c0d-2e3f-5a7b-9c1d-3e4f5a6b7c8e
 status: test
 description: Base rule for AccessDenied correlation.
 references:
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
@@ -13,7 +13,7 @@ references:
     - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.discovery
     - attack.collection
@@ -29,6 +29,7 @@ correlation:
         - S3 ListBuckets Call
     group-by:
         - sourceIPAddress
+        - userIdentity.accessKeyId
     timespan: 5m
     generate: false
 level: high
@@ -40,7 +41,7 @@ description: Base rule for GetCallerIdentity correlation.
 references:
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.discovery
 logsource:
@@ -60,7 +61,7 @@ description: Base rule for S3 ListBuckets correlation.
 references:
 author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-29
 tags:
     - attack.collection
 logsource:

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
@@ -1,4 +1,4 @@
-title: S3 Enumeration After GetCallerIdentity
+title: S3 Enum After GetCallerIdentity
 id: 6c8d0e2f-4a5b-7c9d-1e3f-5a6b7c8d9e0f
 status: test
 description: |

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
@@ -1,0 +1,74 @@
+title: S3 Enumeration After GetCallerIdentity
+id: 6c8d0e2f-4a5b-7c9d-1e3f-5a6b7c8d9e0f
+status: test
+description: |
+    Detects a pattern commonly observed with stolen AWS credentials:
+    the attacker first calls sts:GetCallerIdentity to verify the credentials work,
+    then enumerates S3 buckets with s3:ListBuckets.
+    This temporal sequence is a strong indicator of credential theft because
+    legitimate applications rarely call GetCallerIdentity before S3 operations.
+references:
+    - https://attack.mitre.org/techniques/T1530/
+    - https://attack.mitre.org/techniques/T1078/004/
+    - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.discovery
+    - attack.collection
+    - attack.t1530
+    - attack.t1078.004
+logsource:
+    product: aws
+    service: cloudtrail
+correlation:
+    type: temporal_ordered
+    rules:
+        - GetCallerIdentity Call
+        - S3 ListBuckets Call
+    group-by:
+        - sourceIPAddress
+    timespan: 5m
+    generate: false
+level: high
+---
+title: GetCallerIdentity Call
+id: 6c8d0e2f-4a5b-7c9d-1e3f-5a6b7c8d9e10
+status: test
+description: Base rule for GetCallerIdentity correlation.
+references:
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.discovery
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: sts.amazonaws.com
+        eventName: GetCallerIdentity
+    condition: selection
+level: informational
+---
+title: S3 ListBuckets Call
+id: 6c8d0e2f-4a5b-7c9d-1e3f-5a6b7c8d9e11
+status: test
+description: Base rule for S3 ListBuckets correlation.
+references:
+author: i-wind (@iwind)
+date: 2026-05-03
+modified: 2026-05-03
+tags:
+    - attack.collection
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: s3.amazonaws.com
+        eventName: ListBuckets
+    condition: selection
+level: informational

--- a/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
+++ b/suzaku/aws/cloudtrail/aws_cloudtrail_s3_enum_after_getcalleridentity.yml
@@ -11,7 +11,7 @@ references:
     - https://attack.mitre.org/techniques/T1530/
     - https://attack.mitre.org/techniques/T1078/004/
     - https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:
@@ -38,7 +38,7 @@ id: 6c8d0e2f-4a5b-7c9d-1e3f-5a6b7c8d9e10
 status: test
 description: Base rule for GetCallerIdentity correlation.
 references:
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:
@@ -58,7 +58,7 @@ id: 6c8d0e2f-4a5b-7c9d-1e3f-5a6b7c8d9e11
 status: test
 description: Base rule for S3 ListBuckets correlation.
 references:
-author: i-wind (@iwind)
+author: nishikawaakira (@nishikawaakira)
 date: 2026-05-03
 modified: 2026-05-03
 tags:


### PR DESCRIPTION
## Summary

Adds 9 new AWS CloudTrail Sigma detection rules based on real-world attack patterns. These rules cover IAM persistence, privilege escalation, credential enumeration, and multi-step attack chains.

### New rules

| Rule | Level | Type |
|------|-------|------|
| IAM User Created | high | single |
| Attempt To Create IAM User (AccessDenied) | medium | single |
| IAM Access Key Created | medium | single |
| Attempt To Create IAM Access Key (AccessDenied) | medium | single |
| IAM Admin Policy Attached (AdministratorAccess/PowerUserAccess/IAMFullAccess) | critical | single |
| Attempt To Attach Policy (AccessDenied) | medium | single |
| Many AccessDenied Errors from Single Source (≥10 in 10m) | high | correlation (event_count) |
| S3 Enumeration After GetCallerIdentity (temporal) | high | correlation (temporal_ordered) |
| IAM Persistence Chain: CreateUser → CreateAccessKey (temporal) | critical | correlation (temporal_ordered) |

### Context

These rules were derived from observing attackers who obtained AWS credentials leaked via `.env` files. The observed attack patterns include:

1. **Credential validation**: Attacker calls `sts:GetCallerIdentity` immediately after obtaining credentials
2. **Reconnaissance**: Rapid enumeration of AWS APIs, producing many `AccessDenied` errors
3. **Persistence**: `CreateUser` → `CreateAccessKey` chain to establish backdoor access
4. **Privilege escalation**: Attempting to attach administrative policies to compromised or newly created users
5. **Data discovery**: `s3:ListBuckets` enumeration after identity verification

### MITRE ATT&CK coverage

- T1078.004 — Valid Accounts: Cloud Accounts
- T1098.001 — Account Manipulation: Additional Cloud Credentials
- T1098.003 — Account Manipulation: Additional Cloud Roles
- T1136.003 — Create Account: Cloud Account
- T1530 — Data from Cloud Storage
- T1580 — Cloud Infrastructure Discovery

### Notes

- `CreateAccessKey` (IAM) rules are distinct from the existing `CreateApiKey` (AppSync/API Gateway) rules
- Correlation rules use `event_count` and `temporal_ordered` types
- Success rules use `errorCode|exists: true` filter to exclude all failure codes (not just AccessDenied)
- The "Attempt To Attach Policy" rule intentionally does not filter by policy name because `requestParameters` may be empty on AccessDenied events
- Correlation rules group by both `sourceIPAddress` and `userIdentity.accessKeyId` to reduce false positives behind NAT/proxy