### PR TITLE
feat: add 21 M365 Unified Audit Log detection rules

### DIFF
--- a/sigma/azure/m365/m365_admin_audit_log_config_changed.yml
+++ b/sigma/azure/m365/m365_admin_audit_log_config_changed.yml
@@ -1,0 +1,22 @@
+title: M365 Unified Audit Log Ingestion Disabled
+id: a1f0c2e1-000d-4a00-8a01-00000000000d
+status: experimental
+description: Detects Set-AdminAuditLogConfig disabling UnifiedAuditLogIngestionEnabled, which stops M365 unified audit logging tenant-wide.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.defense-evasion
+    - attack.t1562.008
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Set-AdminAuditLogConfig'
+        Parameters.UnifiedAuditLogIngestionEnabled: 'False'
+    condition: selection
+falsepositives:
+    - Rare; almost always security-relevant.
+level: high

--- a/sigma/azure/m365/m365_application_added.yml
+++ b/sigma/azure/m365/m365_application_added.yml
@@ -1,0 +1,22 @@
+title: M365 Application Registered
+id: a1f0c2e1-0011-4a00-8a01-000000000011
+status: experimental
+description: Detects registration of a new application in the tenant, which can be abused for persistence (e.g. rclone / OAuth data access).
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.t1550.001
+    - attack.t1098.001
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Add application.'
+    condition: selection
+falsepositives:
+    - Legitimate application onboarding.
+level: medium

--- a/sigma/azure/m365/m365_auth_policy_updated_user_consent.yml
+++ b/sigma/azure/m365/m365_auth_policy_updated_user_consent.yml
@@ -1,0 +1,22 @@
+title: M365 Authorization Policy Updated
+id: a1f0c2e1-0010-4a00-8a01-000000000010
+status: experimental
+description: Detects Update authorization policy., e.g. allowing all users to consent to applications, which enables illicit-consent / OAuth abuse.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1550.001
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Update authorization policy.'
+    condition: selection
+falsepositives:
+    - Deliberate tenant policy changes by administrators.
+level: medium

--- a/sigma/azure/m365/m365_azurehound_useragent.yml
+++ b/sigma/azure/m365/m365_azurehound_useragent.yml
@@ -1,0 +1,22 @@
+title: M365 Sign-in from AzureHound
+id: a1f0c2e1-0007-4a00-8a01-000000000007
+status: experimental
+description: Detects an M365/Entra ID sign-in whose user agent identifies the AzureHound directory-enumeration tool.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.discovery
+    - attack.t1526
+    - attack.t1482
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        ExtendedProperties.UserAgent|contains: 'azurehound'
+    condition: selection
+falsepositives:
+    - Authorized red-team / BloodHound assessments.
+level: high

--- a/sigma/azure/m365/m365_casmailbox_protocols_enabled.yml
+++ b/sigma/azure/m365/m365_casmailbox_protocols_enabled.yml
@@ -1,0 +1,21 @@
+title: M365 Mailbox POP/IMAP/OWA Protocol Change
+id: a1f0c2e1-0009-4a00-8a01-000000000009
+status: experimental
+description: Detects Set-CASMailbox, used to enable legacy client-access protocols (POP/IMAP) or OWA, which can facilitate mailbox data collection and MFA bypass.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.collection
+    - attack.t1114.002
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Set-CASMailbox'
+    condition: selection
+falsepositives:
+    - Legitimate mailbox protocol configuration.
+level: medium

--- a/sigma/azure/m365/m365_disable_strong_authentication.yml
+++ b/sigma/azure/m365/m365_disable_strong_authentication.yml
@@ -1,0 +1,22 @@
+title: M365 Strong Authentication (MFA) Disabled for User
+id: a1f0c2e1-0012-4a00-8a01-000000000012
+status: experimental
+description: Detects Disable Strong Authentication., removing per-user MFA and weakening account protection.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.defense-evasion
+    - attack.t1556.006
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Disable Strong Authentication.'
+    condition: selection
+falsepositives:
+    - Administrator resetting a user's MFA registration.
+level: high

--- a/sigma/azure/m365/m365_exchange_new_rolegroup.yml
+++ b/sigma/azure/m365/m365_exchange_new_rolegroup.yml
@@ -1,0 +1,22 @@
+title: M365 Exchange Management Role Group Created
+id: a1f0c2e1-0003-4a00-8a01-000000000003
+status: experimental
+description: Detects creation of an Exchange Online management role group (e.g. granting ApplicationImpersonation), which can be abused for persistence and mailbox access.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.002
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'New-RoleGroup'
+    condition: selection
+falsepositives:
+    - Legitimate delegation of Exchange administration.
+level: medium

--- a/sigma/azure/m365/m365_failed_logins_spray.yml
+++ b/sigma/azure/m365/m365_failed_logins_spray.yml
@@ -1,0 +1,21 @@
+title: M365 Failed User Login (Password Spray / Brute Force)
+id: a1f0c2e1-0006-4a00-8a01-000000000006
+status: experimental
+description: Detects failed M365 sign-ins. A burst of these across many users is indicative of password spraying or brute forcing (msolspray/o365spray).
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.credential-access
+    - attack.t1110.003
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'UserLoginFailed'
+    condition: selection
+falsepositives:
+    - Users mistyping passwords; correlate on volume/distinct-users for higher fidelity.
+level: medium

--- a/sigma/azure/m365/m365_mailbox_audit_age_zeroed.yml
+++ b/sigma/azure/m365/m365_mailbox_audit_age_zeroed.yml
@@ -1,0 +1,22 @@
+title: M365 Mailbox Audit Log Age Limit Changed
+id: a1f0c2e1-000c-4a00-8a01-00000000000c
+status: experimental
+description: Detects Set-Mailbox changing AuditLogAgeLimit (e.g. to 0), reducing or clearing retained mailbox audit data.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.defense-evasion
+    - attack.t1562.001
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Set-Mailbox'
+        Parameters.AuditLogAgeLimit|exists: true
+    condition: selection
+falsepositives:
+    - Legitimate retention policy changes.
+level: medium

--- a/sigma/azure/m365/m365_mailbox_audit_bypass.yml
+++ b/sigma/azure/m365/m365_mailbox_audit_bypass.yml
@@ -1,0 +1,21 @@
+title: M365 Mailbox Audit Bypass Association Configured
+id: a1f0c2e1-000b-4a00-8a01-00000000000b
+status: experimental
+description: Detects Set-MailboxAuditBypassAssociation, which exempts a principal from mailbox audit logging to evade detection.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.defense-evasion
+    - attack.t1562.008
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Set-MailboxAuditBypassAssociation'
+    condition: selection
+falsepositives:
+    - Rare; almost always security-relevant.
+level: high

--- a/sigma/azure/m365/m365_mailbox_forwarding_set.yml
+++ b/sigma/azure/m365/m365_mailbox_forwarding_set.yml
@@ -1,0 +1,25 @@
+title: M365 Mailbox Forwarding Configured via Set-Mailbox
+id: a1f0c2e1-000a-4a00-8a01-00000000000a
+status: experimental
+description: Detects Set-Mailbox configuring mail forwarding (ForwardingSmtpAddress / DeliverToMailboxAndForward), a common email-exfiltration technique.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.collection
+    - attack.exfiltration
+    - attack.t1114.003
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Set-Mailbox'
+    forwarding:
+        - Parameters.ForwardingSmtpAddress|exists: true
+        - Parameters.DeliverToMailboxAndForward|exists: true
+    condition: selection and forwarding
+falsepositives:
+    - Legitimate, business-approved mail forwarding.
+level: high

--- a/sigma/azure/m365/m365_mailbox_permission_added.yml
+++ b/sigma/azure/m365/m365_mailbox_permission_added.yml
@@ -1,0 +1,21 @@
+title: M365 Mailbox Full Access Permission Granted
+id: a1f0c2e1-0004-4a00-8a01-000000000004
+status: experimental
+description: Detects a mailbox permission (e.g. FullAccess) being granted to another principal, a common mailbox-delegation persistence technique.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.t1098.002
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Add-MailboxPermission'
+    condition: selection
+falsepositives:
+    - Legitimate delegation such as shared-mailbox or assistant access.
+level: medium

--- a/sigma/azure/m365/m365_mass_user_deletion.yml
+++ b/sigma/azure/m365/m365_mass_user_deletion.yml
@@ -1,0 +1,21 @@
+title: M365 User Account Deleted
+id: a1f0c2e1-000f-4a00-8a01-00000000000f
+status: experimental
+description: Detects Entra ID user account deletion. A burst of these indicates a destructive/impact action (mass account deletion).
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.impact
+    - attack.t1531
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Delete user.'
+    condition: selection
+falsepositives:
+    - Routine deprovisioning; correlate on volume for mass-deletion.
+level: medium

--- a/sigma/azure/m365/m365_new_inbox_rule.yml
+++ b/sigma/azure/m365/m365_new_inbox_rule.yml
@@ -1,0 +1,23 @@
+title: M365 New Inbox Rule Created
+id: a1f0c2e1-0013-4a00-8a01-000000000013
+status: experimental
+description: Detects New-InboxRule. Attackers create inbox rules to auto-forward, delete, or hide mail (e.g. mark-as-read/move to conceal responses).
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.collection
+    - attack.defense-evasion
+    - attack.t1564.008
+    - attack.t1114.003
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'New-InboxRule'
+    condition: selection
+falsepositives:
+    - Users creating legitimate mail-handling rules.
+level: medium

--- a/sigma/azure/m365/m365_powershell_signin.yml
+++ b/sigma/azure/m365/m365_powershell_signin.yml
@@ -1,0 +1,22 @@
+title: M365 Sign-in with PowerShell User Agent
+id: a1f0c2e1-0008-4a00-8a01-000000000008
+status: experimental
+description: Detects an M365 sign-in performed with a WindowsPowerShell user agent. Scripted PowerShell auth to M365 is used by tools such as MFASweep and MSOLSpray.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.credential-access
+    - attack.initial-access
+    - attack.t1110.003
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        ExtendedProperties.UserAgent|contains: 'WindowsPowerShell'
+    condition: selection
+falsepositives:
+    - Administrators using Exchange Online / MSOnline PowerShell modules interactively.
+level: medium

--- a/sigma/azure/m365/m365_recipient_sendas_added.yml
+++ b/sigma/azure/m365/m365_recipient_sendas_added.yml
@@ -1,0 +1,21 @@
+title: M365 Mailbox SendAs Permission Granted
+id: a1f0c2e1-0005-4a00-8a01-000000000005
+status: experimental
+description: Detects a SendAs recipient permission being granted, allowing another principal to send mail as the mailbox owner.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.t1098.002
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Add-RecipientPermission'
+    condition: selection
+falsepositives:
+    - Legitimate delegation.
+level: medium

--- a/sigma/azure/m365/m365_remove_dlp_policy.yml
+++ b/sigma/azure/m365/m365_remove_dlp_policy.yml
@@ -1,0 +1,21 @@
+title: M365 DLP Compliance Policy Removed
+id: a1f0c2e1-000e-4a00-8a01-00000000000e
+status: experimental
+description: Detects Remove-DlpCompliancePolicy, removing a Data Loss Prevention policy and weakening exfiltration controls.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.defense-evasion
+    - attack.t1562.001
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Remove-DlpCompliancePolicy'
+    condition: selection
+falsepositives:
+    - Legitimate DLP policy lifecycle management.
+level: high

--- a/sigma/azure/m365/m365_role_member_added.yml
+++ b/sigma/azure/m365/m365_role_member_added.yml
@@ -1,0 +1,22 @@
+title: M365 Member Added to Privileged Directory Role
+id: a1f0c2e1-0001-4a00-8a01-000000000001
+status: experimental
+description: Detects a user being added to an Entra ID (Azure AD) directory role such as Global Administrator via the M365 Unified Audit Log.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.003
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Add member to role.'
+    condition: selection
+falsepositives:
+    - Legitimate administrative role assignments.
+level: high

--- a/sigma/azure/m365/m365_role_member_removed.yml
+++ b/sigma/azure/m365/m365_role_member_removed.yml
@@ -1,0 +1,22 @@
+title: M365 Member Removed from Directory Role
+id: a1f0c2e1-0002-4a00-8a01-000000000002
+status: experimental
+description: Detects a user being removed from an Entra ID directory role, which can be used to disrupt access or cover tracks.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.impact
+    - attack.persistence
+    - attack.t1531
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Remove member from role.'
+    condition: selection
+falsepositives:
+    - Legitimate role membership changes.
+level: medium

--- a/sigma/azure/m365/m365_set_inbox_rule.yml
+++ b/sigma/azure/m365/m365_set_inbox_rule.yml
@@ -1,0 +1,22 @@
+title: M365 Existing Inbox Rule Modified
+id: a1f0c2e1-0014-4a00-8a01-000000000014
+status: experimental
+description: Detects Set-InboxRule modifying an existing inbox rule, which can repurpose it to hide or exfiltrate mail.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.collection
+    - attack.defense-evasion
+    - attack.t1564.008
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Set-InboxRule'
+    condition: selection
+falsepositives:
+    - Users adjusting legitimate mail-handling rules.
+level: medium

--- a/sigma/azure/m365/m365_user_updated.yml
+++ b/sigma/azure/m365/m365_user_updated.yml
@@ -1,0 +1,22 @@
+title: M365 User Object Updated
+id: a1f0c2e1-0015-4a00-8a01-000000000015
+status: experimental
+description: Detects Update user. on an Entra ID account. Used here to catch advanced-auditing/policy changes applied via a user update; broad, best used with additional context.
+references:
+    - https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples
+author: Zach Mathis
+date: 2026-07-09
+tags:
+    - attack.defense-evasion
+    - attack.persistence
+    - attack.t1562.008
+logsource:
+    product: azure
+    service: m365
+detection:
+    selection:
+        Operation: 'Update user.'
+    condition: selection
+falsepositives:
+    - Very common routine attribute changes; low fidelity on its own.
+level: low


### PR DESCRIPTION
Adds 21 Sigma rules under `sigma/azure/m365/` that detect the M365 Unified Audit Log detection-engineering samples in [`suzaku-sample-data/azure/det-eng-samples`](https://github.com/Yamato-Security/suzaku-sample-data/tree/main/azure/det-eng-samples).

## Log source

`logsource: { product: azure, service: m365 }` — the `m365` service is added to `azure-timeline` in **Yamato-Security/suzaku#129** (M365 Unified Audit Log support). These rules require that PR to fire. The rules match the UAL `Operation`, and nested values like `ExtendedProperties.UserAgent` / `Parameters.*` (folded into objects by the normalizer in #129).

## Coverage

The 21 rules detect **all 39** det-eng samples (19 CSV + 20 JSON). Highlights:

| Technique | Rule(s) |
|---|---|
| T1098.003 / T1098.001 | Member Added to / Removed from Privileged Directory Role |
| T1098.002 | Exchange Role Group Created; Mailbox FullAccess / SendAs Permission Granted |
| T1110.003 | Failed User Login (spray); Sign-in from AzureHound; Sign-in with PowerShell User Agent |
| T1114.002 / .003 | POP/IMAP/OWA Protocol Change; Mailbox Forwarding via Set-Mailbox |
| T1564.008 | New / Modified Inbox Rule |
| T1556.006 | Strong Authentication (MFA) Disabled |
| T1562.001 / .008 | Mailbox Audit Bypass; Audit Log Age Limit Changed; Unified Audit Log Ingestion Disabled; DLP Policy Removed |
| T1531 / T1550.001 | User Account Deleted; Authorization Policy Updated; Application Registered |

## Notes

- Rules are `status: experimental`. UUIDs are new and unique (no collision with existing rules).
- One low-fidelity fallback (`M365 User Object Updated`, `Operation: Update user.`) covers the "advanced auditing policy removed" sample, whose record exposes no more specific field; flagged `level: low` with a false-positive note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)