### PR TITLE
Sync Sigma m365 and cloud threat-hunting rules

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -33,8 +33,14 @@ jobs:
         run: |
           rm -rf suzaku-rules/sigma/
           mkdir -p suzaku-rules/sigma/
+          # Detection rules for the clouds Suzaku analyzes (AWS CloudTrail, Azure, Microsoft 365).
           mv sigma/rules/cloud/aws suzaku-rules/sigma/
           mv sigma/rules/cloud/azure suzaku-rules/sigma/
+          mv sigma/rules/cloud/m365 suzaku-rules/sigma/
+          # Threat-hunting rules for the same clouds (Sigma keeps these in a separate top-level tree).
+          mkdir -p suzaku-rules/sigma/threat-hunting/
+          mv sigma/rules-threat-hunting/cloud/azure suzaku-rules/sigma/threat-hunting/
+          mv sigma/rules-threat-hunting/cloud/m365 suzaku-rules/sigma/threat-hunting/
 
       - name: Remove filtered sigma rules
         run: |


### PR DESCRIPTION
## Summary

The daily Sigma sync workflow (`update-sigmarule.yaml`) only pulled `rules/cloud/aws` and `rules/cloud/azure`, so **Microsoft 365 rules and all threat-hunting rules were never synced**. This adds them:

- `rules/cloud/m365` → `sigma/m365/` — **19** Microsoft 365 detection rules (`audit`, `exchange`, `threat_detection`, `threat_management`)
- `rules-threat-hunting/cloud/azure` + `rules-threat-hunting/cloud/m365` → `sigma/threat-hunting/` — **3** threat-hunting rules (Sigma keeps these in a separate top-level `rules-threat-hunting/` tree)

Okta/GCP folders are intentionally left out, matching the existing convention of only syncing the clouds Suzaku analyzes (the sync already skips `rules/cloud/gcp`).

## Verified
Ran the exact `mv` steps against a fresh `SigmaHQ/sigma` checkout — exit 0, producing:

```
sigma/aws            55 rules
sigma/azure          130 rules
sigma/m365           19 rules   (new)
sigma/threat-hunting/azure   1 rule   (new)
sigma/threat-hunting/m365    2 rules  (new)
```

The `Remove filtered sigma rules` step scans `sigma/` recursively, so UUID filtering covers the new folders too.

## ⚠️ Companion change needed in the `suzaku` tool for these to *load*
Heads-up: syncing is necessary but not sufficient. SigmaHQ's m365 rules declare `logsource.service` values `threat_management` / `audit` / `exchange` / `threat_detection`, but `suzaku`'s `LogSource::Azure::supported_services()` currently lists only `"m365"` — so the synced m365 detection + threat-hunting rules **won't be loaded** until `src/core/log_source.rs` is updated to recognize those services (and route them via the `Workload`/`RecordType` discriminator). The one azure threat-hunting rule (`service: signinlogs`) already loads. Happy to open that companion PR on `suzaku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
