### PR TITLE
Restore #67's fixed Azure rules under suzaku/temp_sigma_rules/ so the Sigma sync can't wipe them

### DIFF
--- a/suzaku/temp_sigma_rules/README.md
+++ b/suzaku/temp_sigma_rules/README.md
@@ -1,0 +1,36 @@
+# Temporary Sigma rules
+
+This folder holds **temporary stand-ins** for upstream [SigmaHQ](https://github.com/SigmaHQ/sigma) cloud rules whose detection fields do not yet work with Suzaku.
+
+## Why these exist
+
+Some upstream Azure rules match on legacy field names (e.g. `properties.message`) that do not match the field format Suzaku reads (e.g. `operationName`, aligned to the Azure Event Hub format). [@fukusuket](https://github.com/fukusuket) corrected these fields in suzaku-rules #67 and submitted the same fixes back upstream (see PRs below).
+
+The corrected rules originally lived under `sigma/azure/`, but that tree is **disposable**: the daily sync (`.github/workflows/update-sigmarule.yaml`) runs `rm -rf sigma/`, re-pulls fresh upstream rules, and then deletes every rule whose UUID is listed in [`config/filtered_sigma_rules.txt`](../../config/filtered_sigma_rules.txt). So the fixes were wiped on every sync. Hosting them here under `suzaku/` — which the sync never touches — keeps them working.
+
+## How it stays conflict-free
+
+- Suzaku **loads** these rules from `suzaku/` (their UUIDs are **not** in the tool's `config/azure_ignore_rule_list.txt`).
+- The sync **deletes** the broken upstream copies from `sigma/` on every run (their UUIDs **are** in `config/filtered_sigma_rules.txt`), so there is never a duplicate UUID.
+
+Rule content and UUIDs here are identical to suzaku-rules #67.
+
+## Upstream PRs to watch
+
+These are the SigmaHQ PRs that fix the fields upstream. **All were still open as of 2026-07** — check the links for current status:
+
+| Upstream PR | Folder it fixes |
+| --- | --- |
+| [SigmaHQ/sigma#5987](https://github.com/SigmaHQ/sigma/pull/5987) | `activity_logs` — align detection fields to Event Hub format |
+| [SigmaHQ/sigma#5992](https://github.com/SigmaHQ/sigma/pull/5992) | `signin_logs` — align detection fields to Event Hub format |
+| [SigmaHQ/sigma#5993](https://github.com/SigmaHQ/sigma/pull/5993) | `audit_logs` — align detection fields to Event Hub format |
+| [SigmaHQ/sigma#5990](https://github.com/SigmaHQ/sigma/pull/5990) | `signin_logs` — reorganize (placeholder/deprecated rules) |
+
+## How to remove these once upstream lands
+
+When an upstream PR above is merged and the fix has flowed into `sigma/azure/` via the daily sync:
+
+1. Delete the corresponding rules from this folder.
+2. Remove their UUID entries from [`config/filtered_sigma_rules.txt`](../../config/filtered_sigma_rules.txt) so the now-fixed upstream rules are no longer deleted during the sync and load normally instead.
+
+Do both together so there is no gap where the detection stops loading.

--- a/suzaku/temp_sigma_rules/azure/activity_logs/azure_aadhybridhealth_adfs_new_server.yml
+++ b/suzaku/temp_sigma_rules/azure/activity_logs/azure_aadhybridhealth_adfs_new_server.yml
@@ -1,0 +1,30 @@
+title: Azure Active Directory Hybrid Health AD FS New Server
+id: 288a39fc-4914-4831-9ada-270e9dc12cb4
+status: test
+description: |
+    This detection uses azureactivity logs (Administrative category) to identify the creation or update of a server instance in an Azure AD Hybrid health AD FS service.
+    A threat actor can create a new AD Health ADFS service and create a fake server instance to spoof AD FS signing logs. There is no need to compromise an on-prem AD FS server.
+    This can be done programmatically via HTTP requests to Azure.
+references:
+    - https://web.archive.org/web/20220619212736/https://o365blog.com/post/hybridhealthagent/
+    - https://aadinternals.com/talks/HelSec%20August%202021.pdf
+    - https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/identity#microsoftadhybridhealthservice
+    - https://www.inversecos.com/2023/01/detecting-fake-events-in-azure-sign-in.html
+author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research), MSTIC
+date: 2021-08-26
+modified: 2026-05-05
+tags:
+    - attack.defense-impairment
+    - attack.t1578
+logsource:
+    product: azure
+    service: activitylogs
+detection:
+    selection:
+        category: 'Administrative'
+        resourceId|contains: 'AdFederationService'
+        operationName: 'MICROSOFT.ADHYBRIDHEALTHSERVICE/SERVICES/SERVICEMEMBERS/ACTION'
+    condition: selection
+falsepositives:
+    - Legitimate AD FS servers added to an AAD Health AD FS service instance
+level: medium

--- a/suzaku/temp_sigma_rules/azure/activity_logs/azure_aadhybridhealth_adfs_service_delete.yml
+++ b/suzaku/temp_sigma_rules/azure/activity_logs/azure_aadhybridhealth_adfs_service_delete.yml
@@ -1,0 +1,30 @@
+title: Azure Active Directory Hybrid Health AD FS Service Delete
+id: 48739819-8230-4ee3-a8ea-e0289d1fb0ff
+status: test
+description: |
+    This detection uses azureactivity logs (Administrative category) to identify the deletion of an Azure AD Hybrid health AD FS service instance in a tenant.
+    A threat actor can create a new AD Health ADFS service and create a fake server to spoof AD FS signing logs.
+    The health AD FS service can then be deleted after it is not longer needed via HTTP requests to Azure.
+references:
+    - https://web.archive.org/web/20220619212736/https://o365blog.com/post/hybridhealthagent/
+    - https://aadinternals.com/talks/HelSec%20August%202021.pdf
+    - https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/identity#microsoftadhybridhealthservice
+    - https://www.inversecos.com/2023/01/detecting-fake-events-in-azure-sign-in.html
+author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research), MSTIC
+date: 2021-08-26
+modified: 2026-05-05
+tags:
+    - attack.defense-impairment
+    - attack.t1578.003
+logsource:
+    product: azure
+    service: activitylogs
+detection:
+    selection:
+        category: 'Administrative'
+        resourceId|contains: 'AdFederationService'
+        operationName: 'MICROSOFT.ADHYBRIDHEALTHSERVICE/SERVICES/DELETE'
+    condition: selection
+falsepositives:
+    - Legitimate AAD Health AD FS service instances being deleted in a tenant
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_aad_secops_ca_policy_removedby_bad_actor.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_aad_secops_ca_policy_removedby_bad_actor.yml
@@ -1,0 +1,28 @@
+title: CA Policy Removed by Non Approved Actor
+id: 26e7c5e2-6545-481e-b7e6-050143459635
+status: test
+description: Monitor and alert on conditional access changes where non approved actor removed CA Policy.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
+    - https://learnsentinel.blog/2022/05/09/azure-ad-conditional-access-insights-auditing-with-microsoft-sentinel/
+author: Corissa Koopmans, '@corissalea'
+date: 2022-07-19
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.credential-access
+    - attack.persistence
+    - attack.defense-impairment
+    - attack.t1548
+    - attack.t1556
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Delete conditional access policy
+    condition: selection
+falsepositives:
+    - Misconfigured role permissions
+    - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_aad_secops_ca_policy_updatedby_bad_actor.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_aad_secops_ca_policy_updatedby_bad_actor.yml
@@ -1,0 +1,28 @@
+title: CA Policy Updated by Non Approved Actor
+id: 50a3c7aa-ec29-44a4-92c1-fce229eef6fc
+status: test
+description: Monitor and alert on conditional access changes. Is Initiated by (actor) approved to make changes? Review Modified Properties and compare "old" vs "new" value.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
+    - https://learnsentinel.blog/2022/05/09/azure-ad-conditional-access-insights-auditing-with-microsoft-sentinel/
+author: Corissa Koopmans, '@corissalea'
+date: 2022-07-19
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.credential-access
+    - attack.persistence
+    - attack.defense-impairment
+    - attack.t1548
+    - attack.t1556
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Update conditional access policy
+    condition: selection
+falsepositives:
+    - Misconfigured role permissions
+    - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_aad_secops_new_ca_policy_addedby_bad_actor.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_aad_secops_new_ca_policy_addedby_bad_actor.yml
@@ -1,0 +1,24 @@
+title: New CA Policy by Non-approved Actor
+id: 0922467f-db53-4348-b7bf-dee8d0d348c6
+status: test
+description: Monitor and alert on conditional access changes.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure
+    - https://learnsentinel.blog/2022/05/09/azure-ad-conditional-access-insights-auditing-with-microsoft-sentinel/
+author: Corissa Koopmans, '@corissalea'
+date: 2022-07-18
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.t1548
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Add conditional access policy
+    condition: selection
+falsepositives:
+    - Misconfigured role permissions
+    - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_account_created_deleted.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_account_created_deleted.yml
@@ -1,0 +1,29 @@
+title: Account Created And Deleted Within A Close Time Frame
+id: 6f583da0-3a90-4566-a4ed-83c09fe18bbf
+status: test
+description: Detects when an account was created and deleted in a short period of time.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-user-accounts#short-lived-accounts
+    - https://analyticsrules.exchange/analyticrules/bb616d82-108f-47d3-9dec-9652ea0d3bf6/
+author: Mark Morowczynski '@markmorow', MikeDuddington, '@dudders1', Tim Shelton
+date: 2022-08-11
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName:
+            - Add user
+            - Delete user
+        properties.result: success
+    condition: selection
+falsepositives:
+    - Legit administrative action
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_bitlocker_key_retrieval.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_bitlocker_key_retrieval.yml
@@ -1,0 +1,28 @@
+title: Bitlocker Key Retrieval
+id: a0413867-daf3-43dd-9245-734b3a787942
+status: test
+description: Monitor and alert for Bitlocker key retrieval.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#bitlocker-key-retrieval
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#b2c
+    - https://cyberdom.blog/monitor-and-hunting-bitlocker-with-azure-sentinel-2/
+author: Michael Epping, '@mepples21'
+date: 2022-06-28
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: KeyManagement
+        operationName: Read BitLocker key
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_certificate_based_authencation_enabled.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_certificate_based_authencation_enabled.yml
@@ -1,0 +1,28 @@
+title: Certificate-Based Authentication Enabled
+id: c2496b41-16a9-4016-a776-b23f8910dc58
+status: test
+description: Detects when certificate based authentication has been enabled in an Azure Active Directory tenant.
+references:
+    - https://posts.specterops.io/passwordless-persistence-and-privilege-escalation-in-azure-98a01310be3f
+    - https://goodworkaround.com/2022/02/15/digging-into-azure-ad-certificate-based-authentication/
+    - https://docs.azure.cn/en-us/entra/identity/monitoring-health/reference-audit-activities#authentication-methods
+author: Harjot Shah Singh, '@cyb3rjy0t'
+date: 2024-03-26
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.defense-impairment
+    - attack.t1556
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: 'Authentication Methods Policy Update'
+        properties.targetResources|contains: 'AuthenticationMethodsPolicy'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_device_registration_policy_changes.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_device_registration_policy_changes.yml
@@ -1,0 +1,25 @@
+title: Changes to Device Registration Policy
+id: 9494bff8-959f-4440-bbce-fb87a208d517
+status: test
+description: Monitor and alert for changes to the device registration policy.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#device-registrations-and-joins-outside-policy
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#device-registration-service
+author: Michael Epping, '@mepples21'
+date: 2022-06-28
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.defense-impairment
+    - attack.t1484
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'Policy'
+        operationName: 'Set device registration policies'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_new_root_ca_added.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_new_root_ca_added.yml
@@ -1,0 +1,28 @@
+title: New Root Certificate Authority Added
+id: 4bb80281-3756-4ec8-a88e-523c5a6fda9e
+status: test
+description: Detects newly added root certificate authority to an AzureAD tenant to support certificate based authentication.
+references:
+    - https://posts.specterops.io/passwordless-persistence-and-privilege-escalation-in-azure-98a01310be3f
+    - https://goodworkaround.com/2022/02/15/digging-into-azure-ad-certificate-based-authentication/
+    - https://learn.microsoft.com/en-us/purview/audit-log-activities#directory-administration-activities
+author: Harjot Shah Singh, '@cyb3rjy0t'
+date: 2024-03-26
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.defense-impairment
+    - attack.t1556
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: 'Set Company Information'
+        properties.targetResources|contains: 'TrustedCAsForPasswordlessAuth'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_users_added_to_device_admin_roles.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_ad_users_added_to_device_admin_roles.yml
@@ -1,0 +1,31 @@
+title: Users Added to Global or Device Admin Roles
+id: 11c767ae-500b-423b-bae3-b234450736ed
+status: test
+description: Monitor and alert for users added to device admin roles.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#device-administrator-roles
+author: Michael Epping, '@mepples21'
+date: 2022-06-28
+modified: 2026-05-09
+tags:
+    - attack.persistence
+    - attack.initial-access
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: RoleManagement
+        operationName|contains|all:
+            - 'Add'
+            - 'member to role'
+        properties.targetResources|contains:
+            - '7698a772-787b-4ac8-901f-60d6b08affd2'
+            - '62e90394-69f5-4237-9190-012177145e10'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_appid_uri_changes.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_appid_uri_changes.yml
@@ -1,0 +1,30 @@
+title: Application AppID Uri Configuration Changes
+id: 1b45b0d1-773f-4f23-aedc-814b759563b1
+status: test
+description: Detects when a configuration change is made to an applications AppID URI.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#appid-uri-added-modified-or-removed
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
+date: 2022-06-02
+modified: 2026-05-09
+tags:
+    - attack.initial-access
+    - attack.persistence
+    - attack.credential-access
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1552
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName:
+            - Update Application
+            - Update Service principal
+    condition: selection
+falsepositives:
+    - When and administrator is making legitimate AppID URI configuration changes to an application. This should be a planned event.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_credential_added.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_credential_added.yml
@@ -1,0 +1,26 @@
+title: Added Credentials to Existing Application
+id: cbb67ecc-fb70-4467-9350-c910bdf7c628
+status: test
+description: Detects when a new credential is added to an existing application. Any additional credentials added outside of expected processes could be a malicious actor using those credentials.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-credentials
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
+date: 2022-05-26
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.t1098.001
+    - attack.persistence
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName:
+            - Update application - Certificates and secrets management
+            - Update Service principal/Update Application
+    condition: selection
+falsepositives:
+    - When credentials are added/removed as part of the normal working hours/workflows
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_delegated_permissions_all_users.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_delegated_permissions_all_users.yml
@@ -1,0 +1,23 @@
+title: Delegated Permissions Granted For All Users
+id: a6355fbe-f36f-45d8-8efc-ab42465cbc52
+status: test
+description: Detects when highly privileged delegated permissions are granted on behalf of all users
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-granted-highly-privileged-permissions
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Bailey Bercik '@baileybercik', Mark Morowczynski '@markmorow'
+date: 2022-07-28
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Add delegated permission grant
+    condition: selection
+falsepositives:
+    - When the permission is legitimately needed for the app
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_end_user_consent.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_end_user_consent.yml
@@ -1,0 +1,28 @@
+title: End User Consent
+id: 9b2cc4c4-2ad4-416d-8e8e-ee6aa6f5035a
+status: test
+description: Detects when an end user consents to an application
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#end-user-consent
+    - https://research.splunk.com/cloud/10ec9031-015b-4617-b453-c0c1ab729007/
+    - https://mashtitle.com/2025/06/23/husky-corp/
+    - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
+author: Bailey Bercik '@baileybercik', Mark Morowczynski '@markmorow'
+date: 2022-07-28
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: 'Consent to application'
+        properties.targetResources|contains|all:
+            - 'ConsentContext.IsAdminConsent'
+            - 'False'
+    condition: selection
+falsepositives:
+    - Unknown
+level: low

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_end_user_consent_blocked.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_end_user_consent_blocked.yml
@@ -1,0 +1,26 @@
+title: End User Consent Blocked
+id: 7091372f-623c-4293-bc37-20c32b3492be
+status: test
+description: Detects when end user consent is blocked due to risk-based consent.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#end-user-stopped-due-to-risk-based-consent
+    - https://research.splunk.com/cloud/10ec9031-015b-4617-b453-c0c1ab729007/
+    - https://mashtitle.com/2025/06/23/husky-corp/
+    - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
+author: Bailey Bercik '@baileybercik', Mark Morowczynski '@markmorow'
+date: 2022-07-10
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: 'Consent to application'
+        properties.resultReason: 'Microsoft.Online.Security.UserConsentBlockedForRiskyAppsException'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_owner_added.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_owner_added.yml
@@ -1,0 +1,23 @@
+title: Added Owner To Application
+id: 74298991-9fc4-460e-a92e-511aa60baec1
+status: test
+description: Detects when a new owner is added to an application. This gives that account privileges to make modifications and configuration changes to the application.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#new-owner
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
+date: 2022-06-02
+modified: 2026-05-09
+tags:
+    - attack.t1552
+    - attack.credential-access
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Add owner to application
+    condition: selection
+falsepositives:
+    - When a new application owner is added by an administrator
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_permissions_msft.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_permissions_msft.yml
@@ -1,0 +1,25 @@
+title: App Granted Microsoft Permissions
+id: c1d147ae-a951-48e5-8b41-dcd0170c7213
+status: test
+description: Detects when an application is granted delegated or app role permissions for Microsoft Graph, Exchange, Sharepoint, or Azure AD
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-granted-highly-privileged-permissions
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Bailey Bercik '@baileybercik', Mark Morowczynski '@markmorow'
+date: 2022-07-10
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName:
+            - Add delegated permission grant
+            - Add app role assignment to service principal
+    condition: selection
+falsepositives:
+    - When the permission is legitimately needed for the app
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_privileged_permissions.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_privileged_permissions.yml
@@ -1,0 +1,27 @@
+title: App Granted Privileged Delegated Or App Permissions
+id: 5aecf3d5-f8a0-48e7-99be-3a759df7358f
+related:
+    - id: ba2a7c80-027b-460f-92e2-57d113897dbc
+      type: obsolete
+status: test
+description: Detects when administrator grants either application permissions (app roles) or highly privileged delegated permissions
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-granted-highly-privileged-permissions
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Bailey Bercik '@baileybercik', Mark Morowczynski '@markmorow'
+date: 2022-07-28
+modified: 2026-05-09
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.003
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Add app role assignment to service principal
+    condition: selection
+falsepositives:
+    - When the permission is legitimately needed for the app
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_role_added.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_role_added.yml
@@ -1,0 +1,28 @@
+title: App Assigned To Azure RBAC/Microsoft Entra Role
+id: b04934b2-0a68-4845-8a19-bdfed3a68a7a
+status: test
+description: Detects when an app is assigned Azure AD roles, such as global administrator, or Azure RBAC roles, such as subscription owner.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#service-principal-assigned-to-a-role
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Bailey Bercik '@baileybercik', Mark Morowczynski '@markmorow'
+date: 2022-07-19
+modified: 2026-05-09
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.003
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        properties.targetResources|contains: 'Service Principal'
+        operationName:
+            - Add member to role
+            - Add eligible member to role
+            - Add scoped member to role
+    condition: selection
+falsepositives:
+    - When the permission is legitimately needed for the app
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_uri_modifications.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_app_uri_modifications.yml
@@ -1,0 +1,35 @@
+title: Application URI Configuration Changes
+id: 0055ad1f-be85-4798-83cf-a6da17c993b3
+status: test
+description: |
+    Detects when a configuration change is made to an applications URI.
+    URIs for domain names that no longer exist (dangling URIs), not using HTTPS, wildcards at the end of the domain, URIs that are no unique to that app, or URIs that point to domains you do not control should be investigated.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-configuration-changes
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+    - https://analyticsrules.exchange/analyticrules/9fb2ee72-959f-4c2b-bc38-483affc539e4/
+author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
+date: 2022-06-02
+modified: 2026-05-09
+tags:
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1528
+    - attack.t1078.004
+    - attack.persistence
+    - attack.credential-access
+    - attack.privilege-escalation
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: ApplicationManagement
+        operationName:
+            - Update Application
+            - Update Service principal
+        properties.targetResources|contains: 'AppIdentifierUri'
+    condition: selection
+falsepositives:
+    - When and administrator is making legitimate URI configuration changes to an application. This should be a planned event.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_auditlogs_laps_credential_dumping.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_auditlogs_laps_credential_dumping.yml
@@ -1,0 +1,28 @@
+title: Windows LAPS Credential Dump From Entra ID
+id: a4b25073-8947-489c-a8dd-93b41c23f26d
+status: test
+description: Detects when an account dumps the LAPS password from Entra ID.
+references:
+    - https://twitter.com/NathanMcNulty/status/1785051227568632263
+    - https://www.cloudcoffee.ch/microsoft-365/configure-windows-laps-in-microsoft-intune/
+    - https://techcommunity.microsoft.com/t5/microsoft-entra-blog/introducing-windows-local-administrator-password-solution-with/ba-p/1942487
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#device-registration-service
+author: andrewdanis
+date: 2024-06-26
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.t1098.005
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'Device'
+        operationName: 'Recover device local administrator password'
+        properties.additionalDetails.additionalInfo|contains: 'Successfully recovered local credential by device id'
+    condition: selection
+falsepositives:
+    - Approved activity performed by an Administrator.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_change_to_authentication_method.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_change_to_authentication_method.yml
@@ -1,0 +1,29 @@
+title: Change to Authentication Method
+id: 4d78a000-ab52-4564-88a5-7ab5242b20c7
+status: test
+description: Change to authentication method could be an indicator of an attacker adding an auth method to the account so they can have continued access.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#authentication-methods
+author: AlertIQ
+date: 2021-10-10
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.credential-access
+    - attack.defense-impairment
+    - attack.t1556
+    - attack.persistence
+    - attack.t1098
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        properties.loggedByService: 'Authentication Methods'
+        category: 'UserManagement'
+        operationName: 'User registered security info'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_federation_modified.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_federation_modified.yml
@@ -1,0 +1,29 @@
+title: Azure Domain Federation Settings Modified
+id: 352a54e1-74ba-4929-9d47-8193d67aba1e
+status: test
+description: Identifies when an user or application modified the federation settings on the domain.
+references:
+    - https://learn.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-monitor-federation-changes
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Austin Songer
+date: 2021-09-06
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Set federation settings on domain
+    condition: selection
+falsepositives:
+    - Federation Settings being modified or deleted may be performed by a system administrator.
+    - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+    - Federation Settings modified from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_group_user_addition_ca_modification.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_group_user_addition_ca_modification.yml
@@ -1,0 +1,27 @@
+title: User Added To Group With CA Policy Modification Access
+id: 91c95675-1f27-46d0-bead-d1ae96b97cd3
+status: test
+description: Monitor and alert on group membership additions of groups that have CA policy modification access
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Mark Morowczynski '@markmorow', Thomas Detzner '@tdetzner'
+date: 2022-08-04
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.credential-access
+    - attack.persistence
+    - attack.defense-impairment
+    - attack.t1548
+    - attack.t1556
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Add member to group
+    condition: selection
+falsepositives:
+    - Added user to the group is approved
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_group_user_removal_ca_modification.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_group_user_removal_ca_modification.yml
@@ -1,0 +1,27 @@
+title: User Removed From Group With CA Policy Modification Access
+id: 665e2d43-70dc-4ccc-9d27-026c9dd7ed9c
+status: test
+description: Monitor and alert on group membership removal of groups that have CA policy modification access
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Mark Morowczynski '@markmorow', Thomas Detzner '@tdetzner'
+date: 2022-08-04
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.credential-access
+    - attack.persistence
+    - attack.defense-impairment
+    - attack.t1548
+    - attack.t1556
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Remove member from group
+    condition: selection
+falsepositives:
+    - User removed from the group is approved
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_guest_invite_failure.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_guest_invite_failure.yml
@@ -1,0 +1,28 @@
+title: Guest User Invited By Non Approved Inviters
+id: 0b4b72e3-4c53-4d5b-b198-2c58cfef39a9
+status: test
+description: Detects when a user that doesn't have permissions to invite a guest user attempts to invite one.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts#things-to-monitor
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#invited-users
+    - https://analyticsrules.exchange/analyticrules/572e75ef-5147-49d9-9d65-13f2ed1e3a86/
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-10
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.initial-access
+    - attack.persistence
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Invite external user
+        properties.result: failure
+    condition: selection
+falsepositives:
+    - A non malicious user is unaware of the proper process
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_guest_to_member.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_guest_to_member.yml
@@ -1,0 +1,31 @@
+title: User State Changed From Guest To Member
+id: 8dee7a0d-43fd-4b3c-8cd1-605e189d195e
+status: test
+description: Detects the change of user type from "Guest" to "Member" for potential elevation of privilege.
+references:
+    - https://learn.microsoft.com/en-gb/entra/architecture/security-operations-user-accounts#monitoring-external-user-sign-ins
+    - https://analyticsrules.exchange/analyticrules/a09a0b8e-30fe-4ebf-94a0-cffe50f579cd/
+author: MikeDuddington, '@dudders1'
+date: 2022-06-30
+modified: 2026-05-09
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'UserManagement'
+        operationName: 'Update user'
+        properties.targetResources|contains|all:
+            - 'UserType'
+            - 'Guest'
+            - 'Member'
+    condition: selection
+falsepositives:
+    - If this was approved by System Administrator.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_pim_activation_approve_deny.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_pim_activation_approve_deny.yml
@@ -1,0 +1,28 @@
+title: PIM Approvals And Deny Elevation
+id: 039a7469-0296-4450-84c0-f6966b16dc6d
+status: test
+description: Detects when a PIM elevation is approved or denied. Outside of normal operations should be investigated.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-identity-management#azure-ad-roles-assignment
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#access-reviews
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-09
+modified: 2026-05-09
+tags:
+    - attack.persistence
+    - attack.initial-access
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName:
+            - Request Approved
+            - Request Denied
+    condition: selection
+falsepositives:
+    - Actual admin using PIM.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_pim_alerts_disabled.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_pim_alerts_disabled.yml
@@ -1,0 +1,26 @@
+title: PIM Alert Setting Changes To Disabled
+id: aeaef14c-e5bf-4690-a9c8-835caad458bd
+status: test
+description: Detects when PIM alerts are set to disabled.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-identity-management#azure-ad-roles-assignment
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#privileged-identity-management-pim
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-09
+modified: 2026-05-09
+tags:
+    - attack.initial-access
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1078
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Disable PIM Alert
+    condition: selection
+falsepositives:
+    - Administrator disabling PIM alerts as an active choice.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_pim_change_settings.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_pim_change_settings.yml
@@ -1,0 +1,26 @@
+title: Changes To PIM Settings
+id: db6c06c4-bf3b-421c-aa88-15672b88c743
+status: test
+description: Detects when changes are made to PIM roles
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-identity-management#azure-ad-roles-assignment
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#privileged-identity-management-pim
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-09
+modified: 2026-05-09
+tags:
+    - attack.initial-access
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Update role setting in PIM
+    condition: selection
+falsepositives:
+    - Legit administrative PIM setting configuration changes
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_priviledged_role_assignment_add.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_priviledged_role_assignment_add.yml
@@ -1,0 +1,29 @@
+title: User Added To Privilege Role
+id: 49a268a4-72f4-4e38-8a7b-885be690c5b5
+status: test
+description: Detects when a user is added to a privileged role.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-identity-management#azure-ad-roles-assignment
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+    - https://analyticsrules.exchange/analyticrules/4d94d4a9-dc96-410a-8dea-4d4d4584188b/
+    - https://research.splunk.com/cloud/a7da845d-6fae-41cf-b823-6c0b8c55814a/
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-06
+modified: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.initial-access
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'RoleManagement'
+        operationName: 'Add eligible member to role'
+    condition: selection
+falsepositives:
+    - Legtimate administrator actions of adding members from a role
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_priviledged_role_assignment_bulk_change.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_priviledged_role_assignment_bulk_change.yml
@@ -1,0 +1,25 @@
+title: Bulk Deletion Changes To Privileged Account Permissions
+id: 102e11e3-2db5-4c9e-bc26-357d42585d21
+status: test
+description: Detects when a user is removed from a privileged role. Bulk changes should be investigated.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-identity-management#microsoft-entra-roles-assignment
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-05
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.t1098
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'RoleManagement'
+        operationName: 'Remove eligible member from role'
+    condition: selection
+falsepositives:
+    - Legtimate administrator actions of removing members from a role
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_privileged_account_creation.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_privileged_account_creation.yml
@@ -1,0 +1,28 @@
+title: Privileged Account Creation
+id: f7b5b004-dece-46e4-a4a5-f6fd0e1c6947
+status: test
+description: Detects when a new admin is created.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts#changes-to-privileged-accounts
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H', Tim Shelton
+date: 2022-08-11
+modified: 2026-05-09
+tags:
+    - attack.initial-access
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName:
+            - Add user
+            - Add member to role
+        properties.result: success
+    condition: selection
+falsepositives:
+    - A legitimate new admin account being created
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_subscription_permissions_elevation_via_auditlogs.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_subscription_permissions_elevation_via_auditlogs.yml
@@ -1,0 +1,33 @@
+title: Azure Subscription Permission Elevation Via AuditLogs
+id: ca9bf243-465e-494a-9e54-bf9fc239057d
+status: test
+description: |
+    Detects when a user has been elevated to manage all Azure Subscriptions.
+    This change should be investigated immediately if it isn't planned.
+    This setting could allow an attacker access to Azure subscriptions in your environment.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts#assignment-and-elevation
+    - https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin?tabs=azure-portal%2Centra-audit-logs#view-elevate-access-log-entries
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#azure-rbac-elevated-access
+    - https://blog.sonnes.cloud/microsoft-azure-elevate-access-to-resources-with-entra-id-audit-logs-now-available/
+    - https://analyticsrules.exchange/analyticrules/132fdff4-c044-4855-a390-c1b71e0f833b/
+author: Austin Songer @austinsonger
+date: 2021-11-26
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'AzureRBACRoleManagementElevateAccess'
+        operationName: 'User has elevated their access to User Access Administrator for their Azure Resources'
+    condition: selection
+falsepositives:
+    - If this was approved by System Administrator.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_tap_added.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_tap_added.yml
@@ -1,0 +1,28 @@
+title: Temporary Access Pass Added To An Account
+id: fa84aaf5-8142-43cd-9ec2-78cfebf878ce
+status: test
+description: Detects when a temporary access pass (TAP) is added to an account. TAPs added to priv accounts should be investigated
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts#changes-to-privileged-accounts
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#authentication-methods
+    - https://analyticsrules.exchange/analyticrules/d7feb859-f03e-4e8d-8b21-617be0213b13/
+author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
+date: 2022-08-10
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.initial-access
+    - attack.persistence
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: Admin registered security info
+        properties.resultReason: Admin registered temporary access pass method for user
+    condition: selection
+falsepositives:
+    - Administrator adding a legitimate temporary access pass
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_update_risk_and_mfa_registration_policy.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_update_risk_and_mfa_registration_policy.yml
@@ -1,0 +1,26 @@
+title: User Risk and MFA Registration Policy Updated
+id: d4c7758e-9417-4f2e-9109-6125d66dabef
+status: test
+description: |
+    Detects changes and updates to the user risk and MFA registration policy.
+    Attackers can modified the policies to Bypass MFA, weaken security thresholds, facilitate further attacks, maintain persistence.
+references:
+    - https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-mfa-policy
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
+author: Harjot Singh (@cyb3rjy0t)
+date: 2024-08-13
+modified: 2026-05-09
+tags:
+    - attack.persistence
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        properties.loggedByService: 'AAD Management UX'
+        category: 'Policy'
+        operationName: 'Update User Risk and MFA Registration Policy'
+    condition: selection
+falsepositives:
+    - Known updates by administrators.
+level: high

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_user_account_mfa_disable.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_user_account_mfa_disable.yml
@@ -1,0 +1,31 @@
+title: Multi Factor Authentication Disabled For User Account
+id: b18454c8-0be3-41f7-86bc-9c614611b839
+status: test
+description: |
+    Detects changes to the "StrongAuthenticationRequirement" value, where the state is set to "0" or "Disabled".
+    Threat actors were seen disabling multi factor authentication for users in order to maintain or achieve access to the account. Also see in SIM Swap attacks.
+references:
+    - https://www.sans.org/blog/defending-against-scattered-spider-and-the-com-with-cybercrime-intelligence/
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
+author: Harjot Singh (@cyb3rjy0t)
+date: 2024-08-21
+modified: 2026-05-09
+tags:
+    - attack.credential-access
+    - attack.persistence
+logsource:
+    product: azure
+    service: auditlogs
+    definition: 'Requirements: The TargetResources array needs to be mapped accurately in order for this rule to work'
+detection:
+    selection:
+        properties.loggedByService: 'Core Directory'
+        category: 'UserManagement'
+        operationName: 'Update user'
+        properties.targetResources|contains|all:
+            - 'StrongAuthenticationRequirement'
+            - 'Disabled'
+    condition: selection
+falsepositives:
+    - Legitimate authorized activity.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/audit_logs/azure_user_password_change.yml
+++ b/suzaku/temp_sigma_rules/azure/audit_logs/azure_user_password_change.yml
@@ -1,0 +1,32 @@
+title: Password Reset By User Account
+id: 340ee172-4b67-4fb4-832f-f961bdc1f3aa
+status: test
+description: Detect when a user has reset their password in Azure AD
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
+author: YochanaHenderson, '@Yochana-H'
+date: 2022-08-03
+modified: 2026-05-09
+tags:
+    - attack.privilege-escalation
+    - attack.initial-access
+    - attack.persistence
+    - attack.credential-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        category: 'UserManagement'
+        properties.result: 'success'
+        properties.initiatedby|contains: 'UPN'
+    filter:
+        properties.TargetResources|contains: 'UPN'
+        operationName|contains: 'Password reset'
+    condition: selection and filter
+falsepositives:
+    - If this was approved by System Administrator or confirmed user action.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_azurehound_discovery.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_azurehound_discovery.yml
@@ -1,0 +1,25 @@
+title: Discovery Using AzureHound
+id: 35b781cc-1a08-4a5a-80af-42fd7c315c6b
+status: test
+description: Detects AzureHound (A BloodHound data collector for Microsoft Azure) activity via the default User-Agent that is used during its operation after successful authentication.
+references:
+    - https://github.com/BloodHoundAD/AzureHound
+    - https://research.splunk.com/endpoint/1c34549e-c31b-11eb-996b-acde48001122/
+author: Janantha Marasinghe
+date: 2022-11-27
+modified: 2026-05-08
+tags:
+    - attack.discovery
+    - attack.t1087.004
+    - attack.t1526
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        properties.userAgent|contains: 'azurehound'
+        resultType: 0
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_device_registration_or_join_without_mfa.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_device_registration_or_join_without_mfa.yml
@@ -1,0 +1,28 @@
+title: Device Registration or Join Without MFA
+id: 5afa454e-030c-4ab4-9253-a90aa7fcc581
+status: test
+description: Monitor and alert for device registration or join events where MFA was not performed.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#device-registrations-and-joins-outside-policy
+author: Michael Epping, '@mepples21'
+date: 2022-06-28
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        properties.resourceDisplayName: 'Device Registration Service'
+        properties.conditionalAccessStatus: 'success'
+    filter_mfa:
+        properties.authenticationRequirement: 'multiFactorAuthentication'
+    condition: selection and not filter_mfa
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_only_single_factor_auth_required.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_only_single_factor_auth_required.yml
@@ -1,0 +1,29 @@
+title: Azure AD Only Single Factor Authentication Required
+id: 28eea407-28d7-4e42-b0be-575d5ba60b2c
+status: test
+description: Detect when users are authenticating without MFA being required.
+references:
+    - https://learn.microsoft.com/en-gb/entra/architecture/security-operations-user-accounts#monitoring-for-successful-unusual-sign-ins
+author: MikeDuddington, '@dudders1'
+date: 2022-07-27
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.credential-access
+    - attack.stealth
+    - attack.defense-impairment
+    - attack.t1078.004
+    - attack.t1556.006
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 0
+        properties.authenticationRequirement: 'singleFactorAuthentication'
+    condition: selection
+falsepositives:
+    - If this was approved by System Administrator.
+level: low

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_risky_sign_ins_with_singlefactorauth_from_unknown_devices.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_risky_sign_ins_with_singlefactorauth_from_unknown_devices.yml
@@ -1,0 +1,31 @@
+title: Suspicious SignIns From A Non Registered Device
+id: 572b12d4-9062-11ed-a1eb-0242ac120002
+status: test
+description: Detects risky authentication from a non AD registered device without MFA being required.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#non-compliant-device-sign-in
+author: Harjot Singh, '@cyb3rjy0t'
+date: 2023-01-10
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection_main:
+        resultType: 0
+        properties.authenticationRequirement: 'singleFactorAuthentication'
+        properties.riskState: 'atRisk'
+    selection_empty1:
+        properties.deviceDetail.trusttype: ''
+    selection_empty2:
+        properties.deviceDetail.trusttype: null
+    condition: selection_main and 1 of selection_empty*
+falsepositives:
+    - Unknown
+level: high

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_sign_ins_from_noncompliant_devices.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_sign_ins_from_noncompliant_devices.yml
@@ -1,0 +1,25 @@
+title: Sign-ins from Non-Compliant Devices
+id: 4f77e1d7-3982-4ee0-8489-abf2d6b75284
+status: test
+description: Monitor and alert for sign-ins where the device was non-compliant.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#non-compliant-device-sign-in
+author: Michael Epping, '@mepples21'
+date: 2022-06-28
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        properties.deviceDetail.isCompliant: 'false'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_sign_ins_from_unknown_devices.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_sign_ins_from_unknown_devices.yml
@@ -1,0 +1,28 @@
+title: Sign-ins by Unknown Devices
+id: 4d136857-6a1a-432a-82fc-5dd497ee5e7c
+status: test
+description: Monitor and alert for Sign-ins by unknown devices from non-Trusted locations.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-devices#non-compliant-device-sign-in
+author: Michael Epping, '@mepples21'
+date: 2022-06-28
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 0
+        properties.authenticationRequirement: singleFactorAuthentication
+        properties.networkLocationDetails: '[]'
+        properties.deviceDetail.deviceId: ''
+    condition: selection
+falsepositives:
+    - Unknown
+level: low

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_suspicious_signin_bypassing_mfa.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_ad_suspicious_signin_bypassing_mfa.yml
@@ -1,0 +1,32 @@
+title: Potential MFA Bypass Using Legacy Client Authentication
+id: 53bb4f7f-48a8-4475-ac30-5a82ddfdf6fc
+status: test
+description: Detects successful authentication from potential clients using legacy authentication via user agent strings. This could be a sign of MFA bypass using a password spray attack.
+references:
+    - https://web.archive.org/web/20230217071802/https://blooteem.com/march-2022
+    - https://www.microsoft.com/en-us/security/blog/2021/10/26/protect-your-business-from-password-sprays-with-microsoft-dart-recommendations/
+author: Harjot Singh, '@cyb3rjy0t'
+date: 2023-03-20
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.credential-access
+    - attack.stealth
+    - attack.t1078.004
+    - attack.t1110
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 0
+        properties.userAgent|contains:
+            - 'BAV2ROPC'
+            - 'CBAinPROD'
+            - 'CBAinTAR'
+    condition: selection
+falsepositives:
+    - Known Legacy Accounts
+level: high

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_app_device_code_authentication.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_app_device_code_authentication.yml
@@ -1,0 +1,29 @@
+title: Application Using Device Code Authentication Flow
+id: 248649b7-d64f-46f0-9fb2-a52774166fb5
+status: test
+description: |
+    Device code flow is an OAuth 2.0 protocol flow specifically for input constrained devices and is not used in all environments.
+    If this type of flow is seen in the environment and not being used in an input constrained device scenario, further investigation is warranted.
+    This can be a misconfigured application or potentially something malicious.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-authentication-flows
+    - https://research.splunk.com/cloud/d68d8732-6f7e-4ee5-a6eb-737f2b990b91/
+author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
+date: 2022-06-01
+modified: 2026-05-08
+tags:
+    - attack.stealth
+    - attack.t1078
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.initial-access
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        properties.authenticationProtocol: Device Code
+    condition: selection
+falsepositives:
+    - Applications that are input constrained will need to use device code flow and are valid authentications.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_app_ropc_authentication.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_app_ropc_authentication.yml
@@ -1,0 +1,27 @@
+title: Applications That Are Using ROPC Authentication Flow
+id: 55695bc0-c8cf-461f-a379-2535f563c854
+status: test
+description: |
+    Resource owner password credentials (ROPC) should be avoided if at all possible as this requires the user to expose their current password credentials to the application directly.
+    The application then uses those credentials to authenticate the user against the identity provider.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-authentication-flows
+author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
+date: 2022-06-01
+modified: 2026-05-08
+tags:
+    - attack.stealth
+    - attack.t1078
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.initial-access
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        properties.authenticationProtocol: ROPC
+    condition: selection
+falsepositives:
+    - Applications that are being used as part of automated testing or a legacy application that cannot use any other modern authentication flow
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_blocked_account_attempt.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_blocked_account_attempt.yml
@@ -1,0 +1,28 @@
+title: Account Disabled or Blocked for Sign in Attempts
+id: 4afac85c-224a-4dd7-b1af-8da40e1c60bd
+status: test
+description: Detects when an account is disabled or blocked for sign in but tried to log in
+references:
+    - https://learn.microsoft.com/en-gb/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/app-integration/error-code-aadsts50057-user-account-is-disabled
+author: Yochana Henderson, '@Yochana-H'
+date: 2022-06-17
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 50057
+        resultDescription: Failure
+    condition: selection
+falsepositives:
+    - Account disabled or blocked in error
+    - Automation account has been blocked or disabled
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_conditional_access_failure.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_conditional_access_failure.yml
@@ -1,0 +1,30 @@
+title: Sign-in Failure Due to Conditional Access Requirements Not Met
+id: b4a6d707-9430-4f5f-af68-0337f52d5c42
+status: test
+description: Define a baseline threshold for failed sign-ins due to Conditional Access failures
+references:
+    - https://learn.microsoft.com/en-gb/entra/architecture/security-operations-privileged-accounts
+author: Yochana Henderson, '@Yochana-H'
+date: 2022-06-01
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.credential-access
+    - attack.stealth
+    - attack.t1110
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 53003
+        resultDescription: Blocked by Conditional Access
+    condition: selection
+falsepositives:
+    - Service Account misconfigured
+    - Misconfigured Systems
+    - Vulnerability Scanners
+level: high

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_login_to_disabled_account.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_login_to_disabled_account.yml
@@ -1,0 +1,27 @@
+title: Login to Disabled Account
+id: 908655e0-25cf-4ae1-b775-1c8ce9cf43d8
+status: test
+description: Detect failed attempts to sign in to disabled accounts.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/app-integration/error-code-aadsts50057-user-account-is-disabled
+author: AlertIQ
+date: 2021-10-10
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 50057
+        resultDescription: 'User account is disabled. The account has been disabled by an administrator.'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_mfa_denies.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_mfa_denies.yml
@@ -1,0 +1,30 @@
+title: Multifactor Authentication Denied
+id: e40f4962-b02b-4192-9bfe-245f7ece1f99
+status: test
+description: User has indicated they haven't instigated the MFA prompt and could indicate an attacker has the password for the account.
+references:
+    - https://www.microsoft.com/security/blog/2022/03/22/dev-0537-criminal-actor-targeting-organizations-for-data-exfiltration-and-destruction/
+    - https://research.splunk.com/cloud/d0895c20-de71-4fd2-b56c-3fcdb888eba1/
+author: AlertIQ
+date: 2022-03-24
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.credential-access
+    - attack.stealth
+    - attack.t1078.004
+    - attack.t1110
+    - attack.t1621
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        properties.authenticationRequirement: 'multiFactorAuthentication'
+        properties.status.additionalDetails|contains: 'MFA Denied'
+    condition: selection
+falsepositives:
+    - Users actually login but miss-click into the Deny button when MFA prompt.
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_mfa_interrupted.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_mfa_interrupted.yml
@@ -1,0 +1,33 @@
+title: Multifactor Authentication Interrupted
+id: 5496ff55-42ec-4369-81cb-00f417029e25
+status: test
+description: Identifies user login with multifactor authentication failures, which might be an indication an attacker has the password for the account but can't pass the MFA challenge.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes#aadsts-error-codes
+author: AlertIQ
+date: 2021-10-10
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.credential-access
+    - attack.stealth
+    - attack.t1078.004
+    - attack.t1110
+    - attack.t1621
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection_50074:
+        resultType: 50074
+        resultDescription|contains: 'Strong Auth required'
+    selection_500121:
+        resultType: 500121
+        resultDescription|contains: 'Authentication failed during strong authentication request'
+    condition: 1 of selection_*
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_unusual_authentication_interruption.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_unusual_authentication_interruption.yml
@@ -1,0 +1,33 @@
+title: Azure Unusual Authentication Interruption
+id: 8366030e-7216-476b-9927-271d79f13cf3
+status: test
+description: Detects when there is a interruption in the authentication process.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes#aadsts-error-codes
+author: Austin Songer @austinsonger
+date: 2021-11-26
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1078
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection_50097:
+        resultType: 50097
+        resultDescription: 'Device authentication is required'
+    selection_50155:
+        resultType: 50155
+        resultDescription: 'DeviceAuthenticationFailed'
+    selection_50158:
+        resultType: 50158
+        resultDescription: 'ExternalSecurityChallenge - External security challenge was not satisfied'
+    condition: 1 of selection_*
+falsepositives:
+    - Unknown
+level: medium

--- a/suzaku/temp_sigma_rules/azure/signin_logs/azure_user_login_blocked_by_conditional_access.yml
+++ b/suzaku/temp_sigma_rules/azure/signin_logs/azure_user_login_blocked_by_conditional_access.yml
@@ -1,0 +1,30 @@
+title: User Access Blocked by Azure Conditional Access
+id: 9a60e676-26ac-44c3-814b-0c2a8b977adf
+status: test
+description: |
+    Detect access has been blocked by Conditional Access policies.
+    The access policy does not allow token issuance which might be sights≈ of unauthorizeed login to valid accounts.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes#aadsts-error-codes
+author: AlertIQ
+date: 2021-10-10
+modified: 2026-05-08
+tags:
+    - attack.privilege-escalation
+    - attack.persistence
+    - attack.credential-access
+    - attack.initial-access
+    - attack.stealth
+    - attack.t1110
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        resultType: 53003
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium


### PR DESCRIPTION
## Problem

The 55 Azure rules that @fukusuket fixed in #67 (swapping legacy field names such as `properties.message` for the `operationName`/etc. fields Suzaku actually matches on) have stopped loading. They were edited **in place under `sigma/azure/`**, but that tree is disposable:

1. The daily sync (`update-sigmarule.yaml`) runs `rm -rf sigma/` and re-pulls fresh upstream rules — wiping #67's edits.
2. It then deletes every upstream rule whose UUID is in `config/filtered_sigma_rules.txt`.

So after each sync both the upstream rule **and** #67's fixed version are gone, and the detection no longer loads. (Confirmed: all 55 fixed files now differ from #67 / are absent from `sigma/`.)

## Fix

Re-add the fixed versions under a dedicated **`suzaku/temp_sigma_rules/azure/{activity_logs,audit_logs,signin_logs}/`** folder, which the sync never touches (it only `rm -rf`s `sigma/`). The `temp_sigma_rules/` name makes explicit that these are **temporary stand-ins** for the broken upstream rules and can be removed once SigmaHQ ships the field-name fixes upstream. Content is **byte-identical to #67** (extracted from that commit), UUIDs unchanged.

This is conflict-free by construction:
- **The tool loads them:** none of the 55 UUIDs are in the tool's `config/azure_ignore_rule_list.txt`.
- **No duplicate UUIDs:** all 55 UUIDs *are* in `config/filtered_sigma_rules.txt`, so the sync keeps deleting the broken upstream copies from `sigma/`. The upstream rule and the `suzaku/` rule never coexist.

## Scope / verification

- 55 rules restored: 2 `activity_logs`, 37 `audit_logs`, 16 `signin_logs`.
- The 4 count/aggregation rules #67 *deleted* (auth failure/success increase, single-factor auth to important apps, guest users invited) are intentionally **not** re-added.
- All 55 parse as valid YAML with the required keys; no legacy `properties.message` remains; additions only (0 existing files changed); no new duplicate UUIDs introduced.
- No changes to `config/` — the existing `filtered_sigma_rules.txt` and `azure_ignore_rule_list.txt` already do the right thing.