### PR TITLE
feat: expand `abused_aws_api_calls.csv` for enhanced detection capabilities

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,1 +1,7 @@
 # 変更点
+
+## v2.0.0 [2026-07-19]
+
+### 改善
+
+- `config/abused_aws_api_calls.csv` のエントリ数を 43 件から 140 件に拡張。AWS Threat Technique Catalog および MITRE ATT&CK Enterprise Cloud (IaaS) マトリクスを参照し、MFA 改ざん、IAM 権限昇格、CloudWatch Logs 削除、GuardDuty 無効化、ランサムウェア/破壊系 API、Bedrock LLMjacking、ガバナンス/探索系オペレーションのカバレッジを追加。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changes
+
+## v2.0.0 [2026-07-19]
+
+### Improvements
+
+- Expanded `config/abused_aws_api_calls.csv` from 43 to 140 entries by cross-referencing the AWS Threat Technique Catalog and MITRE ATT&CK Enterprise Cloud (IaaS) matrix. New coverage includes MFA tampering, IAM privilege escalation, CloudWatch Logs deletion, GuardDuty disabling, ransomware/destruction APIs, Bedrock LLMjacking, and governance/discovery operations.

--- a/config/abused_aws_api_calls.csv
+++ b/config/abused_aws_api_calls.csv
@@ -1,44 +1,141 @@
 EventName,Description
+AccessKubernetesApi,Access EKS Kubernetes API (T1199.A002)
+AddUserToGroup,Add user to privileged group (T1098.003)
 AssumeRole,Lateral movement via roles
 AssumeRoleWithWebIdentity,Lateral movement via roles
+AssumeRoot,Escalate to org member root account (T1548 / AT1669)
+AttachManagedPolicyToPermissionSet,Attach policy to permission set (T1098.003)
+AttachRolePolicy,Inject permissions onto a role (T1098.003)
 AttachUserPolicy,Inject permissions
+AttachVolume,Attach volume to attacker instance (T1578.001)
+AuthorizeSecurityGroupEgress,Open outbound firewall rule (T1562.007)
+AuthorizeSecurityGroupIngress,Open inbound firewall rule (T1562.007)
+ChangeResourceRecordSets,Modify Route53 records for subdomain takeover (T1491.A001)
+ConsoleLogin,Interactive console sign-in (auth monitoring)
+Converse,Bedrock Converse API abuse for LLMjacking (T1496.A007)
+ConverseStream,Bedrock streaming Converse abuse for LLMjacking (T1496.A007)
+CopyDBSnapshot,Copy RDS snapshot for exfil/encryption (T1486.A003)
+CopyObject,Server-side copy for exfil/encryption (T1486.A001 / T1530.A001)
 CreateAccessKey,Creates long-term credentials for backdoor
+CreateAccount,Create AWS Organizations account (T1666.A001)
+CreateAccountAssignment,Assign IAM Identity Center access (T1098.003)
+CreateCluster,Create ECS/EKS cluster (T1496.A006 / T1496.A010)
+CreateEnvironment,Create CloudShell environment (T1059.009)
 CreateFunction,Deploy attacker-controlled Lambda
 CreateInstanceProfile,IAM persistence for EC2-based access
+CreateKeyPair,Create EC2 key pair for access (T1098.001)
 CreateLoginProfile,Add IAM users (login backdoors)
+CreateNetworkAclEntry,Add network ACL entry to bypass controls (T1562.007)
+CreateNodegroup,Create EKS nodegroup for crypto mining (T1496.A010)
+CreateOpenIDConnectProvider,Add OIDC federation trust (T1484.002)
+CreatePermissionSet,Create IAM Identity Center permission set (T1098.003)
 CreatePolicy,Inject permissions
+CreatePolicyVersion,Swap policy version to escalate (T1098.003)
+CreateRestApi,Create API Gateway REST API (AT1667.001)
 CreateRole,Add custom roles with privileges
+CreateSAMLProvider,Add SAML federation trust (T1484.002)
+CreateSecurityGroup,Create permissive security group (T1562.007 / T1190.A019)
+CreateService,Create ECS service (T1496.A006 / T1578.002)
+CreateSession,Create CloudShell session (T1059.009)
+CreateSnapshot,Create EBS snapshot for exfil (T1578.001)
 CreateUser,Add IAM users (login backdoors)
+CreateVolume,Create volume for data encryption/staging (T1486.A002)
+CreateWorkspaces,Provision WorkSpaces for hijacking (T1496.A009)
+DeactivateMFADevice,Disable MFA to weaken account security (T1556.006)
+DeleteBucket,Delete S3 bucket (T1485.A003)
+DeleteDBCluster,Delete RDS cluster (T1485.A001)
+DeleteDBClusterSnapshot,Delete RDS cluster snapshot (T1485.A001)
+DeleteDBInstance,Delete RDS instance (T1485.A001)
+DeleteDBSnapshot,Delete RDS snapshot (T1485.A001)
+DeleteDetector,Disable GuardDuty detector (T1562.A001)
+DeleteLogGroup,Delete CloudWatch log group (T1562.008)
+DeleteLoginProfile,Remove console access as defense evasion (T1531)
+DeleteLogStream,Delete CloudWatch log stream (T1562.008)
+DeleteMembers,Remove GuardDuty member accounts (T1562.A001)
+DeleteObjects,Bulk S3 object deletion (T1485.A003)
+DeleteObjectVersion,Delete S3 object versions to defeat recovery (T1485.A003)
 DeletePolicy,Remove audit controls
+DeleteRole,Delete IAM role to remove traces (T1070.A001 / T1531)
+DeleteSAMLProvider,Remove SAML provider (T1484.002)
+DeleteSecurityGroup,Remove security group control (T1562.007)
+DeleteSnapshot,Delete EBS snapshot (T1578.003 / T1490)
 DeleteTrail,Disable or delete CloudTrail
+DeleteUser,Delete IAM user to remove traces (T1070.A001 / T1531)
+DeleteVirtualMFADevice,Remove MFA device (account takeover)
+DeregisterImage,Delete AMI image (T1485.A002)
+DescribeCluster,EKS cluster discovery (T1190.A020)
+DescribeDBInstances,RDS discovery (AT1023.001)
+DescribeDBSnapshots,RDS snapshot discovery (AT1023.001)
 DescribeInstances,EC2 and network layout recon
 DescribeVpcs,EC2 and network layout recon
 DetachPolicy,Remove audit controls
+DisableOrganizationAdminAccount,Disable delegated GuardDuty admin (T1562.A001)
+EnableRegion,Enable unused region for stealth ops (T1535)
+ExecuteCommand,ECS container shell execution (T1496.A006)
 GetAccessKeyLastUsed,Recon for keys in use
 GetBucketAcl,S3 recon
 GetBucketPolicy,S3 recon
 GetCallerIdentity,Current credentials recon
+GetFederationToken,Obtain federated temporary credentials (T1098.001)
+GetObject,Read S3 object contents (T1530.A001 / T1552.001)
 GetParameter,Retrieves SSM Parameter Store (may include credentials)
 GetParameterHistory,Gets historical (often unencrypted) versions
+GetRegionOptStatus,Check region opt-in status (T1535 recon)
+GetRole,IAM enumeration (T1087.004)
 GetSecretValue,Retrieves Secrets Manager values
+GetSessionToken,Obtain temporary session credentials (T1098.001)
+GetTokensFromRefreshToken,Cognito refresh token abuse (T1098.A006)
+GetUser,IAM enumeration (T1087.004)
+ImportKeyPair,Import attacker-controlled EC2 key pair (T1098.001)
+InviteAccountToOrganization,Invite account to organization (T1666.A001)
+Invoke,Executes Lambda (can run attacker code)
 InvokeFunction,Executes Lambda (can run attacker code)
+InvokeModel,Bedrock model invocation for LLMjacking (T1496.A007)
+InvokeModelWithResponseStream,Bedrock streaming invocation for LLMjacking (T1496.A007)
+LeaveOrganization,Leave AWS Organization (T1666.A002)
 ListAccessKeys,Enumerates keys on IAM users
 ListBuckets,S3 recon
+ListClusters,EKS cluster enumeration (T1190.A020)
 ListGroups,IAM enumeration
+ListObjects,Enumerate S3 objects (T1619.A001)
 ListParameters,Find credential storage locations
 ListRoles,IAM enumeration
 ListSecrets,Find credential storage locations
 ListUsers,IAM enumeration
+ModifyDBInstance,Modify RDS instance for public/creds access (T1485.A001 / T1213.A013)
+ModifyInstanceAttribute,Modify instance for persistence/evasion (T1578.003)
+ModifySecurityGroupRules,Modify firewall rules (T1562.007)
 PassRole,"Pass privileges to services (e.g. Lambda, EC2)"
+Publish,SNS publish for SMS pumping (T1496.003)
+PutBucketLifecycleConfiguration,Set short lifecycle to auto-delete objects (T1485.001)
 PutBucketPolicy,Inject persistent permissions
+PutBucketVersioning,Disable S3 versioning before deletion (T1485.A003)
 PutEventSelectors,Narrow what gets logged
+PutGroupPolicy,Inject inline permissions via group (T1098.003)
+PutIntegration,Configure API Gateway integration (AT1667.001)
+PutObject,Overwrite/encrypt object for ransom (T1486.A001)
+PutRetentionPolicy,Shorten log retention to evade detection (T1562.008)
 PutRolePolicy,Add custom roles with privileges
 PutUserPolicy,Inject persistent permissions
-PutUserPolicy,Inject permissions
+RegisterDomain,Register domain via Route53 (T1583.001)
+RegisterTaskDefinition,Register ECS task for crypto mining (T1496.A006)
+RequestServiceQuotaIncrease,Raise quotas for mass resource abuse (T1578.005)
+RequestSpotFleet,Launch spot fleet for crypto mining (T1578.002)
+ResolveCase,Close AWS support case to hide activity (T1098.A001)
 RunInstances,"Spin up EC2 instances (crypto mining, tools)"
 SendCommand,Run arbitrary shell commands on EC2
+SendEmail,SES email send for spam/phishing infra (T1496.A001)
+SendRawEmail,SES raw email send for spam/phishing (T1496.A001)
+SendSSHPublicKey,EC2 Instance Connect key push for access (T1098.001)
+SetDefaultPolicyVersion,Set malicious policy version as default (T1098.003)
 StartInstances,"Spin up EC2 instances (crypto mining, tools)"
 StartSession,Interactive shell via SSM
+StopInstances,Stop EC2 instances (T1578.003)
 StopLogging,Disable or delete CloudTrail logs
+TerminateInstances,Destroy EC2 instances (T1578.003 / T1485)
+TransferDomainToAnotherAwsAccount,Transfer domain to attacker account (T1583.001)
+UpdateAccessKey,Activate/rotate access keys for persistence (T1098.001)
 UpdateAssumeRolePolicy,Modify trust relationship (backdoor a role)
+UpdateDetector,Suspend GuardDuty findings (T1562.A001)
+UpdateLoginProfile,Reset console password for hijacked user (T1098.001)
 UpdateTrail,Point logs to attacker-controlled S3


### PR DESCRIPTION
## Summary

This PR expands `config/abused_aws_api_calls.csv` — the lookup table used by suzaku's [`aws-ct-summary`](https://yamato-security.github.io/suzaku/commands/dfir-summary/) command to classify CloudTrail events into "abused" vs. "other" API calls — from **43 to 140 entries**, and fixes two pre-existing issues.

The additions were derived by cross-referencing every technique in the[AWS Threat Technique Catalog](https://aws-samples.github.io/threat-technique-catalog-for-aws/)and the [MITRE ATT&CK Enterprise Cloud (IaaS) matrix](https://attack.mitre.org/matrices/enterprise/cloud/), normalizing each referenced API to its CloudTrail `eventName`, and diffing against the current file.

## Motivation

`aws-ct-summary` looks up each event's `eventName` against this CSV: a hit is bucketed as an **abused API** (with its description), a miss falls into **other API**. The previous list was heavily skewed toward IAM persistence and CloudTrail tampering, leaving several MITRE tactics with little or no coverage. This left real incident activity in the "other" bucket where it is easy to miss during triage.

## Changes

### Fixes

- **Deduplicated `PutUserPolicy`** — the file had two rows for it with slightly different descriptions; merged into a single entry (`Inject persistent permissions`).
- **Added `Invoke`** — the CloudTrail data-event `eventName` for a Lambda invocation is `Invoke`,  not `InvokeFunction`. The existing `InvokeFunction` row is kept as well (low-risk "register both" approach); it can be removed later if real data confirms it never matches.

### New coverage (98 entries added, sorted case-insensitively by `EventName`)

Grouped by priority in the accompanying plan; each entry is tagged with its MITRE / AWS catalog ID.

- **P1 — high-frequency gaps (35):** MFA tampering (`DeactivateMFADevice`, `DeleteVirtualMFADevice`),
  `AssumeRoot`, EC2 Instance Connect (`SendSSHPublicKey`), IAM privilege escalation
  (`CreatePolicyVersion`, `SetDefaultPolicyVersion`, `AttachRolePolicy`, `AddUserToGroup`),
  CloudWatch Logs deletion (`DeleteLogGroup`, `PutRetentionPolicy`), GuardDuty disabling
  (`DeleteDetector`, `UpdateDetector`), and security-group changes (`AuthorizeSecurityGroupIngress`, …).
- **P2 — ransomware / destruction / resource hijacking (39):** S3/RDS/EC2 deletion and encryption
  (`DeleteObjects`, `DeleteDBInstance`, `TerminateInstances`, `CopyObject`), AMI deletion
  (`DeregisterImage`), Bedrock LLMjacking (`InvokeModel`, `Converse`), SES/SNS abuse (`SendEmail`,
  `Publish`), and ECS/EKS/crypto-mining (`RegisterTaskDefinition`, `CreateNodegroup`, `RunInstances` family).
- **P3 — governance / discovery / misc (24):** Organizations operations (`CreateAccount`,
  `LeaveOrganization`), federation & SSO (`CreateSAMLProvider`, `CreateAccountAssignment`),
  CloudShell, Route53 (`ChangeResourceRecordSets`), API Gateway, and region enablement (`EnableRegion`).

## Validation

- CSV parses cleanly; **140 data rows, no duplicates, no empty descriptions.**
- No description contains a comma, so no CSV quoting was introduced.
- `PutUserPolicy` appears exactly once; both `Invoke` and `InvokeFunction` are present.