### PR TITLE
ci: report filtered_sigma_rules.txt entries that match nothing, and drop the three that do

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -51,25 +51,52 @@ jobs:
             echo "$FILTER_FILE not found. Skipping."
             exit 0
           fi
+          entries=0
+          matched=0
+          unmatched_entries=""
           while IFS= read -r line; do
-            uuid=$(echo "$line" | grep -oE '^[a-f0-9\-]{36}')
-            echo "Processing UUID: $uuid"
+            # `|| true` is required: under `set -e` an assignment takes the exit status of its
+            # command substitution, so a blank or comment-only line would abort the whole step
+            # on grep's exit 1 -- silently, before the guard below ever runs.
+            uuid=$(echo "$line" | grep -oE '^[a-f0-9\-]{36}' || true)
             [ -z "$uuid" ] && continue
+            entries=$((entries + 1))
+            echo "Processing UUID: $uuid"
             if files=$(grep -rl "$uuid" "$SIGMA_DIR" --include='*.yml'); then
               :
             else
               status=$?
               if [ "$status" -eq 1 ]; then
+                # The rule this entry names is not in the trees we sync, so the entry is a no-op.
+                # Do not fail the run over it -- report it instead, otherwise the list quietly
+                # accumulates dead entries as upstream deletes and moves rules.
                 echo "No matching files found for UUID: $uuid"
+                echo "::warning::filtered_sigma_rules.txt entry matches no synced rule: $line"
+                unmatched_entries="${unmatched_entries}- \`${line}\`"$'\n'
                 continue
               fi
               exit "$status"
             fi
+            matched=$((matched + 1))
             for f in $files; do
               echo "Deleting $f (matched UUID: $uuid)"
               rm -f "$f"
             done
           done < "$FILTER_FILE"
+
+          unmatched=$((entries - matched))
+          echo "Filter entries: $entries, matched: $matched, matched nothing: $unmatched"
+          {
+            echo "## Filtered Sigma rules"
+            echo ""
+            echo "\`config/filtered_sigma_rules.txt\`: **$entries** entries, **$matched** matched a synced rule, **$unmatched** matched nothing."
+            if [ "$unmatched" -gt 0 ]; then
+              echo ""
+              echo "The entries below did nothing this run. The rules they name are no longer in the trees this workflow syncs, so they can be dropped from the list:"
+              echo ""
+              printf '%s' "$unmatched_entries"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
         shell: bash
 
       - name: Create Text

--- a/config/filtered_sigma_rules.txt
+++ b/config/filtered_sigma_rules.txt
@@ -1,7 +1,4 @@
 4db60cc0-36fb-42b7-9b58-a5b53019fb74 # AWS CloudTrail Important Change - Replaced by Suzaku rules because it is too generic
-28870ae4-6a13-4616-bd1a-235a7fad7458 # Failed Authentications From Countries You Do Not Operate Out Of
-8c944ecb-6970-4541-8496-be554b8e2846 # Placeholder rule
-5f521e4b-0105-4b72-845b-2198a54487b9 # Placeholder rule
 60f6535a-760f-42a9-be3f-c9a0a025906e # Placeholder rule
 905d389b-b853-46d0-9d3d-dea0d3a3cd49 # AWS STS AssumeRole Misuse
 288a39fc-4914-4831-9ada-270e9dc12cb4 # Azure Active Directory Hybrid Health AD FS New Server


### PR DESCRIPTION
Closes #79.

`config/filtered_sigma_rules.txt` names upstream rules by UUID so the daily sync can delete them after pulling SigmaHQ. When upstream moves or removes a rule, the entry naming it goes stale — and nothing in the repo notices. Before #78 the workflow noticed loudly, by failing. After #78 it skips silently, so the list would accumulate dead entries forever. This restores the signal without restoring the failure.

## Changes

**1. Report entries that matched nothing.** The step counts entries, emits a `::warning::` per miss, and writes a run summary. It still never fails the job over a miss. On today's rules the summary is one line:

> `config/filtered_sigma_rules.txt`: **58** entries, **58** matched a synced rule, **0** matched nothing.

And had the three stale entries still been present:

> `config/filtered_sigma_rules.txt`: **61** entries, **58** matched a synced rule, **3** matched nothing.
>
> The entries below did nothing this run. The rules they name are no longer in the trees this workflow syncs, so they can be dropped from the list:
>
> - `28870ae4-6a13-4616-bd1a-235a7fad7458 # Failed Authentications From Countries You Do Not Operate Out Of`
> - `8c944ecb-6970-4541-8496-be554b8e2846 # Placeholder rule`
> - `5f521e4b-0105-4b72-845b-2198a54487b9 # Placeholder rule`

**2. Drop those three entries.**

**3. Fix a `set -e` trap that predates #78.** `uuid=$(echo "$line" | grep -oE ...)` takes the exit status of its command substitution, so a line with no UUID in it aborted the whole step on grep's exit 1 — with **no output at all** and no rules filtered. The `[ -z "$uuid" ] && continue` guard on the next line could never be reached. Reproduced on `main` by prepending one blank line to the current filter file: exit 1, zero log lines, all 202 rules left unfiltered. Added `|| true`. Nobody has hit this because the file happens to contain no blank or comment-only lines, but a comment header would have broken the sync silently.

## Correcting the issue

#79 states the three entries are "gone from SigmaHQ entirely". That is wrong, and the real explanation is tidier: **SigmaHQ PR [#5990](https://github.com/SigmaHQ/sigma/pull/5990) (2026-07-27) moved all three from `rules/cloud/azure/signin_logs/` into `rules-placeholder/`** — a tree this workflow does not sync. They still exist upstream; they are simply unreachable from here, which is also why they were already commented `# Placeholder rule`.

That move is the cause of the outage, and the timing is exact:

| | |
|---|---|
| Last successful sync | 2026-07-26 20:59 UTC |
| SigmaHQ #5990 merged | 2026-07-27 16:28 UTC |
| First failed sync | 2026-07-27 21:12 UTC — the next scheduled run |
| Failures since | 16 consecutive, through 2026-08-11 |

Only the first of the three ever surfaced, because `set -e` killed the step on line 2 before it reached lines 3 and 4.

Note `60f6535a` is also commented `# Placeholder rule` but is **kept** — it still matches `rules/cloud/azure/signin_logs/azure_legacy_authentication_protocols.yml`, which the sync does pull.

## Verification

Against a fresh `--depth 1` SigmaHQ clone, restricted to exactly the trees the workflow syncs (`rules/cloud/{aws,azure,m365}` plus `rules-threat-hunting/cloud/{azure,m365}` — 202 rules), running the step script extracted from the workflow:

| step | filter list | exit | result |
|---|---|---|---|
| `main` | 61 entries | 0 | 144 rules survive |
| this PR | 61 entries | 0 | 144 rules survive, 3 warnings |
| this PR | 58 entries | 0 | 144 rules survive, 0 warnings |

**The synced rule set is byte-for-byte identical in all three** (`diff` of the sorted file lists is empty). Removing the three entries changes nothing about what ships; the only behavior added is reporting.

Also checked: `GITHUB_STEP_SUMMARY` unset (the `act` local-run path in the file's header comment) is handled via `${GITHUB_STEP_SUMMARY:-/dev/null}`, a missing filter file still exits 0, and blank/comment/whitespace lines are now skipped without being counted as entries.

## One tradeoff worth naming

Removing an entry means that if SigmaHQ ever moves one of these rules back into `rules/cloud/`, it will start syncing again rather than being filtered. That seems right — the alternative is keeping entries that report as misses on every run, which would train us to ignore the warning this PR just added. A rule reappearing would show up in the sync PR's diff.
